### PR TITLE
Обработка разыменований после выражений

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -24,29 +24,5 @@
         <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
       </formatting-settings>
     </DBN-SQL>
-    <DBN-PSQL>
-      <case-options enabled="false">
-        <option name="KEYWORD_CASE" value="lower" />
-        <option name="FUNCTION_CASE" value="lower" />
-        <option name="PARAMETER_CASE" value="lower" />
-        <option name="DATATYPE_CASE" value="lower" />
-        <option name="OBJECT_CASE" value="preserve" />
-      </case-options>
-      <formatting-settings enabled="false" />
-    </DBN-PSQL>
-    <DBN-SQL>
-      <case-options enabled="false">
-        <option name="KEYWORD_CASE" value="lower" />
-        <option name="FUNCTION_CASE" value="lower" />
-        <option name="PARAMETER_CASE" value="lower" />
-        <option name="DATATYPE_CASE" value="lower" />
-        <option name="OBJECT_CASE" value="preserve" />
-      </case-options>
-      <formatting-settings enabled="false">
-        <option name="STATEMENT_SPACING" value="one_line" />
-        <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
-        <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
-      </formatting-settings>
-    </DBN-SQL>
   </code_scheme>
 </component>

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -222,7 +222,7 @@ statement
     )
     | SEMICOLON
     ;
-assignment       : (IDENTIFIER | globalMethodCall) acceptor* preprocessor* ASSIGN (preprocessor* expression)?;
+assignment       : (IDENTIFIER | globalMethodCall) acceptor? preprocessor* ASSIGN (preprocessor* expression)?;
 callParamList    : callParam (COMMA callParam)*;
 callParam        : expression?;
 expression       : member (preprocessor* operation preprocessor* member)*;
@@ -238,7 +238,7 @@ globalMethodCall : methodName doCall;
 methodName       : IDENTIFIER;
 complexIdentifier: (IDENTIFIER | newExpression | ternaryOperator | globalMethodCall) modifier*;
 modifier         : accessProperty | accessIndex| accessCall;
-acceptor         : modifier (accessProperty | accessIndex);
+acceptor         : modifier* (accessProperty | accessIndex);
 accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -222,7 +222,7 @@ statement
     )
     | SEMICOLON
     ;
-assignment       : complexIdentifier preprocessor* ASSIGN (preprocessor* expression)?;
+assignment       : (IDENTIFIER | globalMethodCall) acceptor* preprocessor* ASSIGN (preprocessor* expression)?;
 callParamList    : callParam (COMMA callParam)*;
 callParam        : expression?;
 expression       : member (preprocessor* operation preprocessor* member)*;
@@ -238,7 +238,8 @@ globalMethodCall : methodName doCall;
 methodName       : IDENTIFIER;
 complexIdentifier: (IDENTIFIER | newExpression | ternaryOperator | globalMethodCall) modifier*;
 modifier         : accessProperty | accessIndex| accessCall;
-accessCall        : DOT methodCall;
+acceptor         : modifier (accessProperty | accessIndex);
+accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;
 doCall           : LPAREN callParamList RPAREN;

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -222,7 +222,7 @@ statement
     )
     | SEMICOLON
     ;
-assignment       : (IDENTIFIER | globalMethodCall) acceptor? preprocessor* ASSIGN (preprocessor* expression)?;
+assignment       : lValue preprocessor* ASSIGN (preprocessor* expression)?;
 callParamList    : callParam (COMMA callParam)*;
 callParam        : expression?;
 expression       : member (preprocessor* operation preprocessor* member)*;
@@ -239,6 +239,7 @@ methodName       : IDENTIFIER;
 complexIdentifier: (IDENTIFIER | newExpression | ternaryOperator | globalMethodCall) modifier*;
 modifier         : accessProperty | accessIndex| accessCall;
 acceptor         : modifier* (accessProperty | accessIndex);
+lValue           : (IDENTIFIER | globalMethodCall) acceptor?;
 accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -230,7 +230,7 @@ operation        : PLUS | MINUS | MUL | QUOTIENT | MODULO | boolOperation | comp
 compareOperation : LESS | LESS_OR_EQUAL | GREATER | GREATER_OR_EQUAL | ASSIGN | NOT_EQUAL;
 boolOperation    : OR_KEYWORD | AND_KEYWORD;
 unaryModifier    : NOT_KEYWORD | MINUS | PLUS;
-member           : unaryModifier? (constValue | complexIdentifier | ( LPAREN expression RPAREN ));
+member           : unaryModifier? (constValue | complexIdentifier | ( LPAREN expression RPAREN ) modifier*);
 newExpression    : NEW_KEYWORD typeName doCall? | NEW_KEYWORD doCall;
 typeName         : IDENTIFIER;
 methodCall       : methodName doCall;

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -463,6 +463,9 @@ class BSLParserTest {
     setInput("Выполнить");
     assertNotMatches(parser.complexIdentifier());
 
+    setInput("Новый(\"Файл\").Существует()");
+    assertMatches(parser.complexIdentifier());
+
   }
 
   @Test
@@ -622,6 +625,12 @@ class BSLParserTest {
     setInput("Идентификатор[1].Метод().Метод2().Свойство.Метод()[1]");
     assertMatches(parser.expression());
     setInput("Идентификатор.Свойство.Метод().Метод2().Свойство.Метод()[1]");
+    assertMatches(parser.expression());
+
+    setInput("Новый Файл().Существует()");
+    assertMatches(parser.expression());
+
+    setInput("(Новый Файл()).Существует()");
     assertMatches(parser.expression());
 
     setInput("Выполнить");
@@ -822,9 +831,6 @@ class BSLParserTest {
     assertMatches(parser.newExpression());
 
     setInput("Новый(\"Массив\")");
-    assertMatches(parser.newExpression());
-
-    setInput("Новый(\"Файл\").Существует()");
     assertMatches(parser.newExpression());
 
     setInput("А");

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -824,6 +824,9 @@ class BSLParserTest {
     setInput("Новый(\"Массив\")");
     assertMatches(parser.newExpression());
 
+    setInput("Новый(\"Файл\").Существует()");
+    assertMatches(parser.newExpression());
+
     setInput("А");
     assertNotMatches(parser.newExpression());
 

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -541,6 +541,18 @@ class BSLParserTest {
     setInput("А = Б = В.Метод(А)");
     assertMatches(parser.assignment());
 
+    setInput("А.Свойство[0] = В.Метод(А)");
+    assertMatches(parser.assignment());
+
+    setInput("А[0].Свойство = В.Метод(А)");
+    assertMatches(parser.assignment());
+
+    setInput("А.Метод()[0][1].Метод().Свойство = В.Метод(А)");
+    assertMatches(parser.assignment());
+
+    setInput("А.Свойство.Метод() = В.Метод(А)");
+    assertNotMatches(parser.assignment());
+
     setInput("Модуль.Метод().Свойство[А]");
     assertNotMatches(parser.assignment());
 


### PR DESCRIPTION
Изменена грамматика, учтено:

* невозможность использования временных объектов в левой части присваивания
* Поддержка конструкций ``(Выражение).Разыменование()``, в частности ``(Новый Файл()).Существует()``