### PR TITLE
Дополнен простой тип который может быть в описании параметра в коммен…

### DIFF
--- a/src/main/antlr/BSLMethodDescriptionLexer.g4
+++ b/src/main/antlr/BSLMethodDescriptionLexer.g4
@@ -39,7 +39,7 @@ HYPERLINK:
 
 COMPLEX_TYPE:
     LETTER (LETTER | DIGIT)* ' '
-    ( O F | F R O M | RU_I RU_Z  ) ' '
+    ( O F | C O N T A I N S | RU_I RU_Z  ) ' '
     LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)* ':'?;
 
 // KEYWORDS

--- a/src/main/antlr/BSLMethodDescriptionLexer.g4
+++ b/src/main/antlr/BSLMethodDescriptionLexer.g4
@@ -39,7 +39,7 @@ HYPERLINK:
 
 COMPLEX_TYPE:
     LETTER (LETTER | DIGIT)* ' '
-    ( F R O M | RU_I RU_Z ) ' '
+    ( O F | F R O M | RU_I RU_Z  ) ' '
     LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)* ':'?;
 
 // KEYWORDS

--- a/src/main/antlr/BSLMethodDescriptionLexer.g4
+++ b/src/main/antlr/BSLMethodDescriptionLexer.g4
@@ -40,7 +40,7 @@ HYPERLINK:
 COMPLEX_TYPE:
     LETTER (LETTER | DIGIT)* ' '
     ( F R O M | RU_I RU_Z ) ' '
-    LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)* ':';
+    LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)* ':'?;
 
 // KEYWORDS
 PARAMETERS_KEYWORD:     (P A R A M E T E R S        | RU_P RU_A RU_R RU_A RU_M RU_E RU_T RU_R RU_Y) ':';
@@ -57,7 +57,6 @@ DASH    : [-–];
 COLON   : ':';
 COMMA   : ',';
 // OTHER
-OF      : ( O F | RU_I RU_Z);
 COMMENT : '//';
 WORD    : LETTER (LETTER | DIGIT)*;
 DOTSWORD: LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)+;

--- a/src/main/antlr/BSLMethodDescriptionLexer.g4
+++ b/src/main/antlr/BSLMethodDescriptionLexer.g4
@@ -57,6 +57,7 @@ DASH    : [-–];
 COLON   : ':';
 COMMA   : ',';
 // OTHER
+OF      : ( O F | RU_I RU_Z);
 COMMENT : '//';
 WORD    : LETTER (LETTER | DIGIT)*;
 DOTSWORD: LETTER (LETTER | DIGIT)* ('.' LETTER (LETTER | DIGIT)*)+;

--- a/src/main/antlr/BSLMethodDescriptionParser.g4
+++ b/src/main/antlr/BSLMethodDescriptionParser.g4
@@ -100,7 +100,7 @@ type:
     | (simpleType COLON?)
     | complexType
     ;
-simpleType: (WORD | DOTSWORD);
+simpleType: (WORD | DOTSWORD | (WORD SPACE OF SPACE WORD));
 listTypes: simpleType (COMMA SPACE? simpleType)+;
 complexType: COMPLEX_TYPE;
 hyperlinkType: HYPERLINK;

--- a/src/main/antlr/BSLMethodDescriptionParser.g4
+++ b/src/main/antlr/BSLMethodDescriptionParser.g4
@@ -100,7 +100,7 @@ type:
     | (simpleType COLON?)
     | complexType
     ;
-simpleType: (WORD | DOTSWORD | (WORD SPACE OF SPACE WORD));
+simpleType: (WORD | DOTSWORD);
 listTypes: simpleType (COMMA SPACE? simpleType)+;
 complexType: COMPLEX_TYPE;
 hyperlinkType: HYPERLINK;


### PR DESCRIPTION
…тарии, чтобы корректно находился тип в параметре, если он задан как "Массив из Структура".

Данное исправление должно пофиксить ищьюз: https://github.com/1c-syntax/bsl-language-server/issues/1620

когда тип параметра задается например как : 
Массив из Строка
Массив из Структура

`// Делает некоторые вещи с массивом строк
//
// Параметры:
//  МассивСтрок - Массив из Строка - Массив строк
Процедура СделатьЧтоТо(МассивСтрок)

КонецПроцедуры`