### PR TITLE
Добавлены переопределения методов getParent, getRuleContext

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,6 +168,7 @@ sonarqube {
         property("sonar.organization", "1c-syntax")
         property("sonar.projectKey", "1c-syntax_bsl-parser")
         property("sonar.projectName", "BSL Parser")
+        property("sonar.scm.exclusions.disabled", "true")
         property("sonar.coverage.jacoco.xmlReportPaths", "$buildDir/reports/jacoco/test/jacoco.xml")
     }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/BSLParserRuleContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/BSLParserRuleContext.java
@@ -41,7 +41,7 @@ public class BSLParserRuleContext extends ParserRuleContext {
    */
   private final Lazy<String> text = new Lazy<>(super::getText);
   /**
-   * Ленивое хранение токенов узал
+   * Ленивое хранение токенов узла
    */
   private final Lazy<List<Token>> tokens = new Lazy<>(this::computeTokens);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/BSLParserRuleContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/BSLParserRuleContext.java
@@ -31,9 +31,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Расширение базового класса контекста парсера
+ */
 public class BSLParserRuleContext extends ParserRuleContext {
 
+  /**
+   * Ленивое хранение текста узла
+   */
   private final Lazy<String> text = new Lazy<>(super::getText);
+  /**
+   * Ленивое хранение токенов узал
+   */
   private final Lazy<List<Token>> tokens = new Lazy<>(this::computeTokens);
 
   public BSLParserRuleContext() {
@@ -42,25 +51,6 @@ public class BSLParserRuleContext extends ParserRuleContext {
 
   public BSLParserRuleContext(ParserRuleContext parent, int invokingStateNumber) {
     super(parent, invokingStateNumber);
-  }
-
-  @Override
-  public String getText() {
-    return text.getOrCompute();
-  }
-
-  public List<Token> getTokens() {
-    return tokens.getOrCompute();
-  }
-
-  private List<Token> computeTokens() {
-    if (children == null) {
-      return Collections.emptyList();
-    }
-
-    List<Token> results = new ArrayList<>();
-    getTokensFromParseTree(this, results);
-    return Collections.unmodifiableList(results);
   }
 
   private static void getTokensFromParseTree(ParseTree tree, List<Token> tokens) {
@@ -75,4 +65,34 @@ public class BSLParserRuleContext extends ParserRuleContext {
       }
     }
   }
+
+  @Override
+  public String getText() {
+    return text.getOrCompute();
+  }
+
+  public List<Token> getTokens() {
+    return tokens.getOrCompute();
+  }
+
+  @Override
+  public BSLParserRuleContext getParent() {
+    return (BSLParserRuleContext) super.getParent();
+  }
+
+  @Override
+  public BSLParserRuleContext getRuleContext() {
+    return (BSLParserRuleContext) super.getRuleContext();
+  }
+
+  private List<Token> computeTokens() {
+    if (children == null) {
+      return Collections.emptyList();
+    }
+
+    List<Token> results = new ArrayList<>();
+    getTokensFromParseTree(this, results);
+    return Collections.unmodifiableList(results);
+  }
+
 }


### PR DESCRIPTION
Добавлены переопределения методов getParent, getRuleContext в BSLParserRuleContext

Closes: #101