### PR TITLE
Добавлена поддержка тестера в части нескольких блоков кода и процедур

### DIFF
--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -27,7 +27,7 @@ options {
 }
 
 // ROOT
-file: shebang? preprocessor* moduleVars? preprocessor* (fileCodeBlockBeforeSub subs)? fileCodeBlock EOF;
+file: shebang? preprocessor* moduleVars? preprocessor* (fileCodeBlockBeforeSub subs)*? fileCodeBlock EOF;
 
 // preprocessor
 shebang          : HASH PREPROC_EXCLAMATION_MARK (PREPROC_ANY | PREPROC_IDENTIFIER)*;

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -1091,8 +1091,9 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     var file = parser.file();
     assertMatches(file);
     var subs = file.subs();
-    assertMatches(subs);
-    var listSubs = subs.sub();
+    subs.forEach(this::assertMatches);
+
+    var listSubs = subs.get(0).sub();
     listSubs.forEach(this::assertMatches);
     var func = listSubs.get(0);
     assertMatches(func);
@@ -1116,8 +1117,8 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     var file = parser.file();
     assertMatches(file);
     var subs = file.subs();
-    assertMatches(subs);
-    var listSubs = subs.sub();
+    subs.forEach(this::assertMatches);
+    var listSubs = subs.get(0).sub();
     listSubs.forEach(this::assertMatches);
     var func = listSubs.get(0);
     assertMatches(func);
@@ -1131,9 +1132,8 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     file = parser.file();
     assertMatches(file);
     subs = file.subs();
-    assertMatches(subs);
-    listSubs = subs.sub();
-    listSubs.forEach(this::assertMatches);
+    subs.forEach(this::assertMatches);
+    listSubs = subs.get(0).sub();
     var proc = listSubs.get(0);
     assertMatches(proc);
     var procDeclare = proc.procedure().procDeclaration();
@@ -1159,9 +1159,8 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     var file = parser.file();
     assertMatches(file);
     var subs = file.subs();
-    assertMatches(subs);
-    var listSubs = subs.sub();
-    listSubs.forEach(this::assertMatches);
+    subs.forEach(this::assertMatches);
+    var listSubs = subs.get(0).sub();
     var proc = listSubs.get(0);
     assertMatches(proc);
     var subCodeblock = proc.procedure().subCodeBlock();
@@ -1190,8 +1189,8 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     var file = parser.file();
     assertMatches(file);
     var subs = file.subs();
-    assertMatches(subs);
-    var listSubs = subs.sub();
+    subs.forEach(this::assertMatches);
+    var listSubs = subs.get(0).sub();
     listSubs.forEach(this::assertMatches);
     var proc = listSubs.get(0);
     assertMatches(proc);


### PR DESCRIPTION
Closes: #67

Надо обсудить: мы получаем в итоге брейкингчендж в части перехода с единственного наличия блока кода до методов и блока методов к массиву таковых