### PR TITLE
Реализована поддержка функционального формата ВызватьИсключение

### DIFF
--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -160,17 +160,7 @@ subCodeBlock     : subVars? codeBlock;
 // statements
 continueStatement : CONTINUE_KEYWORD;
 breakStatement    : BREAK_KEYWORD;
-raiseStatement    : RAISE_KEYWORD
-    (
-        expression?
-        | (LPAREN description=expression
-            (COMMA category=expression
-            (COMMA code=expression
-            (COMMA additionalCause=expression
-            (COMMA cause=expression)?)?)?)?
-          RPAREN)
-    )
-    ;
+raiseStatement    : RAISE_KEYWORD (expression? | doCall);
 ifStatement
     : ifBranch elsifBranch* elseBranch? ENDIF_KEYWORD
     ;

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -160,7 +160,17 @@ subCodeBlock     : subVars? codeBlock;
 // statements
 continueStatement : CONTINUE_KEYWORD;
 breakStatement    : BREAK_KEYWORD;
-raiseStatement    : RAISE_KEYWORD expression?;
+raiseStatement    : RAISE_KEYWORD
+    (
+        expression?
+        | (LPAREN description=expression
+            (COMMA category=expression
+            (COMMA code=expression
+            (COMMA additionalCause=expression
+            (COMMA cause=expression)?)?)?)?
+          RPAREN)
+    )
+    ;
 ifStatement
     : ifBranch elsifBranch* elseBranch? ENDIF_KEYWORD
     ;

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -1284,11 +1284,10 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     assertThat(statement.compoundStatement()).isNotNull();
     assertThat(statement.compoundStatement().raiseStatement()).isNotNull();
     var raise = statement.compoundStatement().raiseStatement();
-    assertThat(raise.description).isNotNull();
-    assertThat(raise.category).isNotNull();
-    assertThat(raise.code).isNotNull();
-    assertThat(raise.additionalCause).isNotNull();
-    assertThat(raise.cause).isNull();
+    assertThat(raise.expression()).isNull();
+    assertThat(raise.doCall()).isNotNull();
+    assertThat(raise.doCall().callParamList()).isNotNull();
+    assertThat(raise.doCall().callParamList().callParam()).isNotNull().hasSize(4);
   }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -1266,4 +1266,29 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     assertThat(annotation2.annotationParams()).isNotNull();
     assertThat(annotation2.annotationParams().annotationParam()).isNotNull().hasSize(3);
   }
+
+  @Test
+  void TestRaise() {
+    setInput("ВызватьИсключение (\"Документ не может быть проведен\", " +
+      "КатегорияОшибки.ОшибкаКонфигурации, " +
+      "\"ERR.DOCS.0001\", " +
+      "\"Клиенту запрещена отгрузка\");");
+
+    var file = parser.file();
+    assertMatches(file);
+    assertThat(file.fileCodeBlock()).isNotNull();
+    assertThat(file.fileCodeBlock().codeBlock()).isNotNull();
+    assertThat(file.fileCodeBlock().codeBlock().statement()).isNotNull().hasSize(1);
+    var statement = file.fileCodeBlock().codeBlock().statement().get(0);
+    assertThat(statement).isNotNull();
+    assertThat(statement.compoundStatement()).isNotNull();
+    assertThat(statement.compoundStatement().raiseStatement()).isNotNull();
+    var raise = statement.compoundStatement().raiseStatement();
+    assertThat(raise.description).isNotNull();
+    assertThat(raise.category).isNotNull();
+    assertThat(raise.code).isNotNull();
+    assertThat(raise.additionalCause).isNotNull();
+    assertThat(raise.cause).isNull();
+  }
+
 }


### PR DESCRIPTION
Closes: #164

```bsl
ВызватьИсключение ("Документ не может быть проведен", 
      КатегорияОшибки.ОшибкаКонфигурации,
      "ERR.DOCS.0001", 
      "Клиенту запрещена отгрузка");
      
ВызватьИсключение "string";

ВызватьИсключение ("string");
```

![parseTree](https://user-images.githubusercontent.com/9591731/156910843-c64d3856-a6d5-4379-9fe2-f3b7521c82c8.png)