### PR TITLE
Исправлена ошибка разбор условия препроцессора

### DIFF
--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -49,9 +49,10 @@ preproc_expression
     | preproc_logicalExpression
     ;
 preproc_logicalOperand
-    : (PREPROC_LPAREN PREPROC_NOT_KEYWORD? preproc_logicalOperand PREPROC_RPAREN)
+    : (PREPROC_NOT_KEYWORD? PREPROC_LPAREN preproc_logicalOperand PREPROC_RPAREN)
     | (PREPROC_NOT_KEYWORD? preproc_symbol)
     | (PREPROC_LPAREN preproc_logicalExpression PREPROC_RPAREN)
+    | (PREPROC_NOT_KEYWORD? PREPROC_LPAREN preproc_logicalExpression PREPROC_RPAREN)
     ;
 preproc_logicalExpression
     : preproc_logicalOperand (preproc_boolOperation preproc_logicalOperand)*

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserTest.java
@@ -110,6 +110,9 @@ class BSLParserTest extends AbstractParserTest<BSLParser, BSLLexer> {
     setInput("Если ТонкийКлиент И ВебКлиент Тогда", BSLLexer.PREPROCESSOR_MODE);
     assertMatches(parser.preproc_if());
 
+    setInput("IF NOT Server OR NOT(ExternalConnection OR ExternalConnection) THEN", BSLLexer.PREPROCESSOR_MODE);
+    assertMatches(parser.preproc_if());
+
     setInput("Если MacOS ИЛИ Linux Тогда", BSLLexer.PREPROCESSOR_MODE);
     assertMatches(parser.preproc_if());
 


### PR DESCRIPTION
Исправлена ошибка разбор условия препроцессора с отрицанием вложенного условия

```bsl
#IF NOT Server OR NOT(ExternalConnection OR ExternalConnection) THEN
#EndIf
```

Подобная инструкция препроцессора ломала разбор