### PR TITLE
fix(description): preserve all value types in Collection of T1, T2

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/CollectionTypeDescription.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/CollectionTypeDescription.java
@@ -28,6 +28,7 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Класс для хранения описания типа коллекции.
@@ -52,10 +53,13 @@ public class CollectionTypeDescription implements TypeDescription {
   String collectionName;
 
   /**
-   * Значение элемента коллекции
+   * Список значений типов элементов коллекции.
+   * <p>
+   * Соответствует записям вида {@code Массив из Тип1, Тип2}. Для коллекций
+   * без указания типов значений список пустой.
    */
   @Accessors(fluent = true)
-  TypeDescription valueType;
+  List<TypeDescription> valueTypes;
 
   /**
    * Элемент описания имени коллекции
@@ -63,15 +67,37 @@ public class CollectionTypeDescription implements TypeDescription {
   @Accessors(fluent = true)
   DescriptionElement element;
 
+  /**
+   * Удобный аксессор для случая «одно значение типа элементов»: первый элемент
+   * {@link #valueTypes}, либо {@link SimpleTypeDescription#EMPTY} если список
+   * пустой. Оставлен для обратной совместимости со старым API.
+   */
+  public TypeDescription valueType() {
+    return valueTypes.isEmpty() ? SimpleTypeDescription.EMPTY : valueTypes.get(0);
+  }
+
   public static TypeDescription create(String collectionName,
                                        DescriptionElement element,
                                        String description,
                                        TypeDescription valueType,
                                        List<ParameterDescription> fieldList) {
-    var valueTypeString = valueType.name();
+    return create(collectionName, element, description, List.of(valueType), fieldList);
+  }
+
+  public static TypeDescription create(String collectionName,
+                                       DescriptionElement element,
+                                       String description,
+                                       List<TypeDescription> valueTypes,
+                                       List<ParameterDescription> fieldList) {
+    var meaningfulValues = valueTypes.stream()
+      .filter(vt -> !vt.name().isEmpty())
+      .collect(Collectors.toUnmodifiableList());
+    var joined = meaningfulValues.stream()
+      .map(TypeDescription::name)
+      .collect(Collectors.joining(", "));
     var name = collectionName;
-    if (!valueTypeString.isEmpty()) {
-      name += "<" + valueTypeString + ">";
+    if (!joined.isEmpty()) {
+      name += "<" + joined + ">";
     }
 
     return new CollectionTypeDescription(
@@ -79,7 +105,7 @@ public class CollectionTypeDescription implements TypeDescription {
       description.strip(),
       fieldList,
       collectionName.strip().intern(),
-      valueType,
+      meaningfulValues,
       element
     );
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/CollectionTypeDescription.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/CollectionTypeDescription.java
@@ -67,23 +67,6 @@ public class CollectionTypeDescription implements TypeDescription {
   @Accessors(fluent = true)
   DescriptionElement element;
 
-  /**
-   * Удобный аксессор для случая «одно значение типа элементов»: первый элемент
-   * {@link #valueTypes}, либо {@link SimpleTypeDescription#EMPTY} если список
-   * пустой. Оставлен для обратной совместимости со старым API.
-   */
-  public TypeDescription valueType() {
-    return valueTypes.isEmpty() ? SimpleTypeDescription.EMPTY : valueTypes.get(0);
-  }
-
-  public static TypeDescription create(String collectionName,
-                                       DescriptionElement element,
-                                       String description,
-                                       TypeDescription valueType,
-                                       List<ParameterDescription> fieldList) {
-    return create(collectionName, element, description, List.of(valueType), fieldList);
-  }
-
   public static TypeDescription create(String collectionName,
                                        DescriptionElement element,
                                        String description,

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
@@ -586,11 +586,9 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
         case SIMPLE -> SimpleTypeDescription.create(name, element, description.toString(), fieldList);
         case COLLECTION -> CollectionTypeDescription.create(
           name, element, description.toString(),
-          valueTypes.isEmpty()
-            ? List.<TypeDescription>of(SimpleTypeDescription.EMPTY)
-            : valueTypes.stream()
-                .map(vt -> vt.build(lineShift, firstLineCharShift))
-                .toList(),
+          valueTypes.stream()
+            .map(vt -> vt.build(lineShift, firstLineCharShift))
+            .toList(),
           fieldList
         );
         case HYPERLINK -> HyperlinkTypeDescription.create(

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
@@ -499,7 +499,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
     private final int level;
     private final List<TempParameterData> fields;
     private final TypeDescription.Variant variant;
-    private @Nullable TempParameterTypeData valueType;
+    private final List<TempParameterTypeData> valueTypes;
     private @Nullable Token linkParamsToken;
 
     private final SimpleRange range;
@@ -511,7 +511,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
       this.description = new StringJoiner("\n");
       this.linkParamsToken = null;
       this.fields = new ArrayList<>();
-      this.valueType = null;
+      this.valueTypes = new ArrayList<>();
       this.range = range;
     }
 
@@ -571,7 +571,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
     private void addType(BSLDescriptionParser.TypeContext type) {
       var fakeParam = TempParameterData.fake();
       fakeParam.addType(type, null);
-      fakeParam.lastType().ifPresent(lastType -> valueType = lastType);
+      valueTypes.addAll(fakeParam.types);
     }
 
     private TypeDescription build(int lineShift, int firstLineCharShift) {
@@ -586,7 +586,11 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
         case SIMPLE -> SimpleTypeDescription.create(name, element, description.toString(), fieldList);
         case COLLECTION -> CollectionTypeDescription.create(
           name, element, description.toString(),
-          valueType == null ? SimpleTypeDescription.EMPTY : valueType.build(lineShift, firstLineCharShift),
+          valueTypes.isEmpty()
+            ? List.<TypeDescription>of(SimpleTypeDescription.EMPTY)
+            : valueTypes.stream()
+                .map(vt -> vt.build(lineShift, firstLineCharShift))
+                .toList(),
           fieldList
         );
         case HYPERLINK -> HyperlinkTypeDescription.create(

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReaderCollectionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReaderCollectionTest.java
@@ -74,4 +74,37 @@ class MethodDescriptionReaderCollectionTest {
       .containsExactly("Число", "Строка");
     assertThat(collection.name()).isEqualToIgnoringCase("Массив<Число, Строка>");
   }
+
+  @Test
+  void singleValueTypeIsPreservedInParameters() {
+    var src = "// Параметры:\n//  Парам - Массив из Число\n";
+    var description = MethodDescription.create(getTokens(src));
+    var params = description.getParameters();
+    assertThat(params).hasSize(1);
+    var types = params.getFirst().types();
+    assertThat(types).hasSize(1);
+    var collection = (CollectionTypeDescription) types.getFirst();
+    assertThat(collection.collectionName()).isEqualToIgnoringCase("Массив");
+    assertThat(collection.valueTypes())
+      .extracting(TypeDescription::name)
+      .containsExactly("Число");
+  }
+
+  @Test
+  void multipleValueTypesArePreservedInParameters() {
+    var src = "// Параметры:\n//  Парам - Массив из Число, Строка\n";
+    var description = MethodDescription.create(getTokens(src));
+    var params = description.getParameters();
+    assertThat(params).hasSize(1);
+    var types = params.getFirst().types();
+    assertThat(types).hasSize(1);
+    var collection = (CollectionTypeDescription) types.getFirst();
+    assertThat(collection.collectionName()).isEqualToIgnoringCase("Массив");
+    assertThat(collection.valueTypes())
+      .as("в параметрах оба value-типа должны быть сохранены, как и в returns")
+      .extracting(TypeDescription::name)
+      .containsExactly("Число", "Строка");
+    assertThat(collection.name()).isEqualToIgnoringCase("Массив<Число, Строка>");
+  }
+
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReaderCollectionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReaderCollectionTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of BSL Parser.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>, Sergey Batanov <sergey.batanov@dmpas.ru>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Parser is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Parser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Parser.
+ */
+package com.github._1c_syntax.bsl.parser.description.reader;
+
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import com.github._1c_syntax.bsl.parser.BSLTokenizer;
+import com.github._1c_syntax.bsl.parser.description.CollectionTypeDescription;
+import com.github._1c_syntax.bsl.parser.description.MethodDescription;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регресс: для записи {@code Массив из Тип1, Тип2} парсер должен сохранять все
+ * value-типы, а не только последний.
+ */
+class MethodDescriptionReaderCollectionTest {
+
+  private List<Token> getTokens(String example) {
+    var tokenizer = new BSLTokenizer(example);
+    return tokenizer.getTokens().stream()
+      .filter(token -> token.getType() == BSLParser.LINE_COMMENT)
+      .collect(Collectors.toList());
+  }
+
+  @Test
+  void singleValueTypeIsPreserved() {
+    var src = "// Возвращаемое значение:\n// Массив из Число\n";
+    var description = MethodDescription.create(getTokens(src));
+    var returns = description.getReturnedValue();
+    assertThat(returns).hasSize(1);
+    var collection = (CollectionTypeDescription) returns.getFirst();
+    assertThat(collection.collectionName()).isEqualToIgnoringCase("Массив");
+    assertThat(collection.valueTypes())
+      .extracting(TypeDescription::name)
+      .containsExactly("Число");
+  }
+
+  @Test
+  void multipleValueTypesArePreserved() {
+    var src = "// Возвращаемое значение:\n// Массив из Число, Строка\n";
+    var description = MethodDescription.create(getTokens(src));
+    var returns = description.getReturnedValue();
+    assertThat(returns).hasSize(1);
+    var collection = (CollectionTypeDescription) returns.getFirst();
+    assertThat(collection.collectionName()).isEqualToIgnoringCase("Массив");
+    assertThat(collection.valueTypes())
+      .as("Массив из Число, Строка → оба value-типа должны быть сохранены")
+      .extracting(TypeDescription::name)
+      .containsExactly("Число", "Строка");
+    assertThat(collection.name()).isEqualToIgnoringCase("Массив<Число, Строка>");
+  }
+}


### PR DESCRIPTION
## Summary
- При парсинге `Массив из Число, Строка` в `MethodDescriptionReader` сохранялся только последний из value-типов (`lastType()`), из-за чего `CollectionTypeDescription.valueType()` отдавал `Строка`, а `Число` молча терялось.
- `TempParameterTypeData.valueType` (singleton) заменён на `valueTypes: List<TempParameterTypeData>`, в который складываются все собранные типы из `listTypes`.
- `CollectionTypeDescription` теперь хранит `List<TypeDescription> valueTypes`; Имя коллекции рендерится как `Имя<T1, T2, ...>`.
- Добавлен регрессионный тест `MethodDescriptionReaderCollectionTest`: одиночный value-тип и множественные value-types.

## Test plan
- [x] `./gradlew test` — все существующие тесты зелёные
- [x] Новый `MethodDescriptionReaderCollectionTest` зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)