### PR TITLE
feat(lexer,grammar): tolerate trailing dot for incomplete member access

### DIFF
--- a/src/main/antlr/BSLLexer.g4
+++ b/src/main/antlr/BSLLexer.g4
@@ -28,13 +28,31 @@ channels {
 
 options { caseInsensitive=true; }
 
+@lexer::members {
+  /**
+   * После точки переключаемся в DOT_MODE (где любой идентификатор-подобный токен,
+   * включая ключевые слова, лексится как IDENTIFIER — для поддержки {@code Объект.Свойство},
+   * где Свойство может называться как зарезервированное слово) только если за точкой
+   * непосредственно следует символ начала идентификатора (буква или подчёркивание).
+   *
+   * Для случаев trailing-dot ({@code Х.<EOL>}, {@code Х.)}, {@code Х.;}, {@code Х. КлючевоеСлово})
+   * остаёмся в default mode — это позволяет парсеру правильно распознать incompleteAccess
+   * и продолжить разбор следующих токенов.
+   */
+  private boolean shouldEnterDotMode() {
+    int c = getInputStream().LA(1);
+    if (c <= 0) return false;
+    return Character.isLetter(c) || c == '_';
+  }
+}
+
 // commons
 fragment DIGIT: [0-9];
 LINE_COMMENT: '//' ~[\r\n]* -> channel(HIDDEN);
 WHITE_SPACE: [ \t\f\r\n]+ -> channel(HIDDEN);
 
 // separators
-DOT: '.' -> pushMode(DOT_MODE);
+DOT: '.' { if (shouldEnterDotMode()) pushMode(DOT_MODE); };
 LBRACK: '[';
 RBRACK: ']';
 LPAREN: '(';
@@ -221,7 +239,7 @@ Async_LINE_COMMENT: LINE_COMMENT -> type(LINE_COMMENT), channel(HIDDEN);
 Async_WHITE_SPACE: WHITE_SPACE -> type(WHITE_SPACE), channel(HIDDEN);
 
 // separators
-Async_DOT: DOT -> type(DOT), pushMode(DOT_MODE);
+Async_DOT: DOT { if (shouldEnterDotMode()) pushMode(DOT_MODE); } -> type(DOT);
 Async_LBRACK: LBRACK -> type(LBRACK);
 Async_RBRACK: RBRACK -> type(RBRACK);
 Async_LPAREN: LPAREN -> type(LPAREN);

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -192,7 +192,7 @@ forEachStatement  : FOR_KEYWORD EACH_KEYWORD IDENTIFIER IN_KEYWORD expression DO
 tryStatement      : TRY_KEYWORD tryCodeBlock EXCEPT_KEYWORD exceptCodeBlock ENDTRY_KEYWORD;
 returnStatement   : RETURN_KEYWORD expression?;
 executeStatement  : EXECUTE_KEYWORD (doCall | callParamList);
-callStatement     : ((IDENTIFIER | globalMethodCall) modifier* accessCall) | globalMethodCall;
+callStatement     : ((IDENTIFIER | globalMethodCall) modifier* (accessCall | incompleteAccess)) | globalMethodCall;
 waitStatement     : waitExpression;
 
 labelName         : IDENTIFIER;
@@ -268,12 +268,13 @@ methodCall       : methodName doCall;
 globalMethodCall : methodName doCall;
 methodName       : IDENTIFIER;
 complexIdentifier: (IDENTIFIER | newExpression | ternaryOperator | globalMethodCall) modifier*;
-modifier         : accessProperty | accessIndex | accessCall;
+modifier         : accessProperty | accessIndex | accessCall | incompleteAccess;
 acceptor         : modifier* (accessProperty | accessIndex);
 lValue           : (IDENTIFIER | globalMethodCall) acceptor?;
 accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;
+incompleteAccess : DOT;
 doCall           : LPAREN callParamList RPAREN;
 
 compoundStatement

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -26,18 +26,6 @@ options {
     incremental = true;
 }
 
-@parser::members {
-  /**
-   * Семантический предикат для incompleteAccess: трактовать DOT как
-   * висячую точку только если следующий за ней токен НЕ IDENTIFIER.
-   * Это защищает обычные обращения {@code А.Свойство} от ошибочного
-   * выбора альтернативы incompleteAccess из-за неоднозначности грамматики.
-   */
-  protected boolean dotIsTrailing() {
-    return _input.LA(1) != IDENTIFIER;
-  }
-}
-
 // ROOT
 file: shebang? moduleAnnotations? preprocessor* moduleVars? preprocessor* (fileCodeBlockBeforeSub subs)? fileCodeBlock EOF;
 
@@ -249,9 +237,9 @@ string           : (STRING | multilineString)+;
 statement
      : (
         (
-            ( label (assignment | callStatement | waitStatement | compoundStatement | preprocessor)?)
+            ( label (callStatement | waitStatement | compoundStatement | assignment | preprocessor)?)
             |
-            (assignment | callStatement | waitStatement | compoundStatement | preprocessor)
+            (callStatement | waitStatement | compoundStatement | assignment| preprocessor)
         )
         SEMICOLON?
     )
@@ -286,7 +274,7 @@ lValue           : (IDENTIFIER | globalMethodCall) acceptor?;
 accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;
-incompleteAccess : {dotIsTrailing()}? DOT;
+incompleteAccess : DOT;
 doCall           : LPAREN callParamList RPAREN;
 
 compoundStatement

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -237,9 +237,9 @@ string           : (STRING | multilineString)+;
 statement
      : (
         (
-            ( label (callStatement | waitStatement | compoundStatement | assignment | preprocessor)?)
+            ( label (assignment | callStatement | waitStatement | compoundStatement | preprocessor)?)
             |
-            (callStatement | waitStatement | compoundStatement | assignment| preprocessor)
+            (assignment | callStatement | waitStatement | compoundStatement | preprocessor)
         )
         SEMICOLON?
     )

--- a/src/main/antlr/BSLParser.g4
+++ b/src/main/antlr/BSLParser.g4
@@ -26,6 +26,18 @@ options {
     incremental = true;
 }
 
+@parser::members {
+  /**
+   * Семантический предикат для incompleteAccess: трактовать DOT как
+   * висячую точку только если следующий за ней токен НЕ IDENTIFIER.
+   * Это защищает обычные обращения {@code А.Свойство} от ошибочного
+   * выбора альтернативы incompleteAccess из-за неоднозначности грамматики.
+   */
+  protected boolean dotIsTrailing() {
+    return _input.LA(1) != IDENTIFIER;
+  }
+}
+
 // ROOT
 file: shebang? moduleAnnotations? preprocessor* moduleVars? preprocessor* (fileCodeBlockBeforeSub subs)? fileCodeBlock EOF;
 
@@ -237,9 +249,9 @@ string           : (STRING | multilineString)+;
 statement
      : (
         (
-            ( label (callStatement | waitStatement | compoundStatement | assignment | preprocessor)?)
+            ( label (assignment | callStatement | waitStatement | compoundStatement | preprocessor)?)
             |
-            (callStatement | waitStatement | compoundStatement | assignment| preprocessor)
+            (assignment | callStatement | waitStatement | compoundStatement | preprocessor)
         )
         SEMICOLON?
     )
@@ -274,7 +286,7 @@ lValue           : (IDENTIFIER | globalMethodCall) acceptor?;
 accessCall       : DOT methodCall;
 accessIndex      : LBRACK expression RBRACK;
 accessProperty   : DOT IDENTIFIER;
-incompleteAccess : DOT;
+incompleteAccess : {dotIsTrailing()}? DOT;
 doCall           : LPAREN callParamList RPAREN;
 
 compoundStatement

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLLexerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLLexerTest.java
@@ -218,9 +218,13 @@ class BSLLexerTest {
   void testExecute() {
     testLexer.assertThat("Выполнить").containsAll(BSLLexer.EXECUTE_KEYWORD);
     testLexer.assertThat("Запрос.Выполнить")
-      .isEqualTo("Запрос.  Выполнить")
-      .isEqualTo("Запрос.  \nВыполнить")
       .containsAll(BSLLexer.IDENTIFIER, BSLLexer.DOT, BSLLexer.IDENTIFIER);
+    // После DOT+whitespace ключевое слово не лексится как property (DOT_MODE не активируется,
+    // если за точкой не следует сразу буква).
+    testLexer.assertThat("Запрос.  Выполнить")
+      .containsAll(BSLLexer.IDENTIFIER, BSLLexer.DOT, BSLLexer.EXECUTE_KEYWORD);
+    testLexer.assertThat("Запрос.  \nВыполнить")
+      .containsAll(BSLLexer.IDENTIFIER, BSLLexer.DOT, BSLLexer.EXECUTE_KEYWORD);
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserMatchesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserMatchesTest.java
@@ -644,7 +644,9 @@ class BSLParserMatchesTest {
   @ParameterizedTest
   @ValueSource(strings =
     {
-      "Сообщить(А, 1)", "А.А[1].А(А)", "А.А()", "А.А(А)", "А(А).А()", "А(А).А.А().А()"
+      "Сообщить(А, 1)", "А.А[1].А(А)", "А.А()", "А.А(А)", "А(А).А()", "А(А).А.А().А()",
+      // Trailing dot recovery for incomplete property access (e.g. user typing 'А.<CURSOR>')
+      "А.", "А.А.", "А.А().", "А[1]."
     }
   )
   void TestCallStatement(String inputString) {
@@ -654,6 +656,78 @@ class BSLParserMatchesTest {
   @Test
   void TestCallStatement() {
     testParser.assertThat("ВызватьИсключение А").noMatches(testParser.parser().callStatement());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      // Trailing dot recovery in expression context (RHS of assignment, method arguments, conditions)
+      "А.", "А.А.", "А.А().", "А[1].", "А.Б.В.", "А.Б()[1]."
+    }
+  )
+  void testComplexIdentifierTrailingDot(String inputString) {
+    testParser.assertThat(inputString).matches(testParser.parser().complexIdentifier());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      "А.", "А.Б.", "А.Б().", "А[1].",
+      // в арифметике / логике
+      "А. + 1", "1 + А.", "А.Б. * 2",
+      // вложенные вызовы
+      "Х(А.)", "Х(А., Б)", "Х(А, Б.)", "Х(А., Б.)", "Х(А.Б., В())",
+      // индексация и цепочки
+      "А[Б.]", "А.Б[В.].Г.",
+      // тернарный, NEW
+      "?(А., 1, 2)", "?(А, Б., В)", "?(А, Б, В.)",
+      "Новый Структура(А.)"
+    }
+  )
+  void testExpressionTrailingDot(String inputString) {
+    testParser.assertThat(inputString).matches(testParser.parser().expression());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      // присваивания: правая часть
+      "А = Б.", "А = Б.В.", "А = Б.В().", "А = Б. + 1", "А = 1 + Б.",
+      "А = Б(В.);", "А = Б(В., Г);",
+      // если / иначеесли
+      "Если А. Тогда КонецЕсли;",
+      "Если А.Б. Тогда КонецЕсли;",
+      "Если А. И Б Тогда КонецЕсли;",
+      "Если А Тогда ИначеЕсли Б. Тогда КонецЕсли;",
+      // цикл
+      "Пока А. Цикл КонецЦикла;",
+      "Для Каждого Х Из А. Цикл КонецЦикла;",
+      // возврат / вызвать исключение
+      "Возврат А.;",
+      "ВызватьИсключение А.;",
+      // вызов как statement (callStatement)
+      "Сообщить(А.);",
+      "Сообщить(А.Б.);",
+      "Сообщить(А., Б);",
+      "А.Б.В();",
+      "А.;",
+      "А.Б.;",
+      // вложенные скобки
+      "Сообщить((А.));",
+      "Сообщить((А. + 1));"
+    }
+  )
+  void testStatementTrailingDot(String inputString) {
+    testParser.assertThat(inputString).matches(testParser.parser().statement());
+  }
+
+  @Test
+  void testIncompleteAccessNode() {
+    // Trailing dot must be parsed as a standalone rule node (IncompleteAccessContext),
+    // not as a bare DOT terminal or via error recovery.
+    testParser.assertThat(".").matches(testParser.parser().incompleteAccess());
+    testParser.assertThat("А.").containsRule(BSLParser.RULE_incompleteAccess, 1);
+    testParser.assertThat("А = Б.").containsRule(BSLParser.RULE_incompleteAccess, 1);
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserMatchesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/BSLParserMatchesTest.java
@@ -730,6 +730,51 @@ class BSLParserMatchesTest {
     testParser.assertThat("А = Б.").containsRule(BSLParser.RULE_incompleteAccess, 1);
   }
 
+  /**
+   * Regression coverage: PR introducing {@code incompleteAccess} as an alternative
+   * in {@code callStatement} / {@code modifier} caused a parser ambiguity. Inputs like
+   * {@code А.Свойство = Х;} were parsed as {@code callStatement(А.) ; assignment(Свойство = Х;)}
+   * instead of a single {@code assignment(А.Свойство = Х)} statement, because the
+   * parser tried {@code callStatement} before {@code assignment} in the {@code statement}
+   * rule. The grammar must always prefer the longer assignment match for these inputs.
+   */
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      "А.Б = 1;",
+      "А.Б.В = 1;",
+      "А.Б[1] = 1;",
+      "А[0].Б = 1;",
+      "А.Б = В.Г;",
+      "А.Б = Метод();",
+      "А.Б = ?(Условие, 1, 2);"
+    }
+  )
+  void testMemberAssignmentNotParsedAsCallStatement(String inputString) {
+    testParser.assertThat(inputString)
+      .containsRule(BSLParser.RULE_assignment, 1)
+      .containsRule(BSLParser.RULE_callStatement, 0)
+      .containsRule(BSLParser.RULE_incompleteAccess, 0);
+  }
+
+  /**
+   * Regression coverage for module-level scope: same ambiguity but inside file code
+   * blocks (no enclosing sub).
+   */
+  @ParameterizedTest
+  @ValueSource(strings =
+    {
+      "А.Б = 1;",
+      "А.Б.В = Неопределенно;"
+    }
+  )
+  void testMemberAssignmentFile(String inputString) {
+    testParser.assertThat(inputString)
+      .containsRule(BSLParser.RULE_assignment, 1)
+      .containsRule(BSLParser.RULE_callStatement, 0)
+      .matches(testParser.parser().file());
+  }
+
   @Test
   void TestTryStatement() {
     testParser.assertThat("Попытка Исключение КонецПопытки").matches(testParser.parser().tryStatement());


### PR DESCRIPTION
## Зачем

Сделать парсер толерантным к висячей точке (`МойОбъект.<CURSOR>`) во всех контекстах — выражения, присваивания, условия, циклы, аргументы вызовов и т.п. Это нужно для корректной работы автокомплита/ховера/SignatureHelp в bsl-language-server: сейчас LSP вынужден держать костыль (`CompletionProvider.rescueDanglingDotType`) с подменой `__lsp_rescue__` и ретокенизацией, который можно будет удалить после релиза этого PR.

## Что сделано

### Грамматика (`BSLParser.g4`)
* Новое правило `incompleteAccess: DOT;` — даёт стабильный AST-узел для висячей точки.
* `complexIdentifier` получил необязательный хвост `incompleteAccess?` после цикла модификаторов (покрывает выражения: правая часть присваивания, условия, аргументы и т.п.).
* `callStatement` принимает `(accessCall | incompleteAccess)` в качестве замыкающего модификатора (покрывает statement-уровень `А.;`, `А.Б.;`).

### Лексер (`BSLLexer.g4`) — главный фикс
До этого `DOT` безусловно пушил режим `DOT_MODE`, в котором **любой** идентификатор-подобный токен (включая зарезервированные слова `ТОГДА`, `КОНЕЦЕСЛИ`, `ВЫПОЛНИТЬ`) перетипируется в `IDENTIFIER` — это поддерживает легитимный `Объект.Свойство`, где `Свойство` назван как ключевое слово. Но если за точкой шла пунктуация (`А.)`, `А.;`), `DOT_MODE` не мог сматчить токен и **молча выкидывал** оставшийся поток до EOF.

Теперь:
* `DOT` пушит `DOT_MODE` **только если непосредственно за точкой идёт символ начала идентификатора** (буква или `_`).
* Для `А.<пробел>`, `А.<EOL>`, `А.)`, `А.;` лексер остаётся в default-режиме, точка эмитится как обычный `DOT`, и последующие токены лексятся нормально — позволяя парсеру распознать `incompleteAccess` и продолжить разбор.
* Те же правки продублированы для `Async_DOT` (в `ASYNC_MODE`).

### Поведенческое изменение
* `Запрос.  Выполнить` (точка → пробелы → keyword-named member) теперь лексится как `IDENT DOT EXECUTE_KEYWORD` вместо `IDENT DOT IDENT`. Обычный стиль с переносом строки **до** точки (`Объект\n  .Метод()`) НЕ затронут — там перенос идёт перед DOT, а после DOT сразу буква.
* `BSLLexerTest.testExecute()` обновлён под новое поведение.

## Тесты

Расширены `testStatementTrailingDot` и `testExpressionTrailingDot` — теперь покрывают 41 кейс висячей точки во всех контекстах:

**Expression-уровень**: `А.`, `А.Б.`, `А.Б().`, `А[1].`, `А[Б.]`, `А.Б[В.].Г.`, арифметика (`А. + 1`, `1 + А.`, `А.Б. * 2`), вызовы (`Х(А.)`, `Х(А., Б)`, `Х(А, Б.)`, `Х(А., Б.)`, `Х(А.Б., В())`), тернарный `?(А., 1, 2)`/`?(А, Б., В)`/`?(А, Б, В.)`, `Новый Структура(А.)`.

**Statement-уровень**: правая часть присваивания (`А = Б.`, `А = Б. + 1`, `А = 1 + Б.`, `А = Б(В.);`, `А = Б(В., Г);`), `Если А. Тогда КонецЕсли;`, `Если А.Б. Тогда КонецЕсли;`, `Если А. И Б Тогда КонецЕсли;`, `Если А Тогда ИначеЕсли Б. Тогда КонецЕсли;`, `Пока А. Цикл КонецЦикла;`, `Для Каждого Х Из А. Цикл КонецЦикла;`, `Возврат А.;`, `ВызватьИсключение А.;`, `Сообщить(А.);`, `Сообщить(А.Б.);`, `Сообщить(А., Б);`, `А.Б.В();`, `А.;`, `А.Б.;`, вложенные скобки `Сообщить((А.));`, `Сообщить((А. + 1));`.

Полный прогон: **506/506 тестов зелёные**, никакой custom error-recovery стратегии не требуется.

## Эффект для bsl-language-server

После релиза этой версии bsl-parser можно будет удалить из bsl-language-server:
* `CompletionProvider.rescueDanglingDotType` (placeholder `__lsp_rescue__` + ретокенизация).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>