### PR TITLE
fix(description): не разрезать структуру на многострочном типе поля

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
@@ -217,7 +217,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
     if (lastReadParam.isEmpty()) {
       return ctx;
     }
-    lastReadParam.addType(ctx.type(), ctx.typeDescription());
+    lastReadParam.addContinuationType(ctx.type(), ctx.typeDescription());
     return ctx;
   }
 
@@ -413,6 +413,25 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
       }
     }
 
+    /**
+     * Добавить дополнительный тип из continuation-строки вида {@code - Тип - описание},
+     * относящейся к составному типу (std453 п.5.2.5, 5.3). Если последний тип уже
+     * содержит поля (т.е. мы внутри списка свойств структуры), то тип принадлежит
+     * самому глубокому активному полю, а не верхнеуровневому списку типов.
+     */
+    private void addContinuationType(BSLDescriptionParser.@Nullable TypeContext paramType,
+                                     BSLDescriptionParser.@Nullable TypeDescriptionContext paramDescription) {
+      if (isEmpty() || paramType == null) {
+        return;
+      }
+      var lastType = lastType();
+      if (lastType.isPresent() && lastType.get().hasFields()) {
+        lastType.get().addContinuationType(paramType, paramDescription);
+      } else {
+        addType(paramType, paramDescription);
+      }
+    }
+
     private void addType(BSLDescriptionParser.ListTypeContext paramType,
                          BSLDescriptionParser.@Nullable TypeDescriptionContext paramDescription) {
       var hyperlinkType = paramType.hyperlinkType();
@@ -553,6 +572,19 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
         return Optional.of(fields.getLast());
       }
       return Optional.empty();
+    }
+
+    private boolean hasFields() {
+      return !fields.isEmpty();
+    }
+
+    /**
+     * Передать дополнительный тип из continuation-строки самому глубокому активному
+     * полю (по образцу {@link #addTypeDescription}, который так же спускается в поля).
+     */
+    private void addContinuationType(BSLDescriptionParser.TypeContext type,
+                                     BSLDescriptionParser.@Nullable TypeDescriptionContext description) {
+      lastField().ifPresent(field -> field.addContinuationType(type, description));
     }
 
     private void addField(BSLDescriptionParser.FieldContext fieldContext) {

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
@@ -770,6 +770,63 @@ class BSLDescriptionReaderTest {
     assertThat(hyperlink.range()).isEqualTo(SimpleRange.create(2, 3, 2, 37));
   }
 
+  @Test
+  void parseStructureReturnFieldWithMultilineType() {
+    // given: возвращается Структура, у первого поля тип задан на двух строках
+    // (составной тип, std453 п.5.3 — каждый тип с новой строки и с дефиса).
+    var methodDescription = parseMethodDescriptionString("""
+      // Возвращаемое значение:
+      //  Структура:
+      //   * Подпись - ДвоичныеДанные - результат подписания.
+      //             - Строка - подписанный КонвертXML.
+      //   * Комментарий - Строка - комментарий.
+      //   * ДатаПодписи - Дата - дата подписи.
+      """);
+
+    // when / then: ровно один тип возврата (Структура) со всеми тремя полями,
+    // а continuation-строка типа не должна "разрезать" структуру на второй тип.
+    assertThat(methodDescription.getReturnedValue()).hasSize(1);
+    var structure = methodDescription.getReturnedValue().getFirst();
+    assertThat(structure.name()).isEqualTo("Структура");
+    assertThat(structure.fields())
+      .extracting(ParameterDescription::name)
+      .containsExactly("Подпись", "Комментарий", "ДатаПодписи");
+    // у поля Подпись — оба типа из многострочного составного описания.
+    assertThat(structure.fields().getFirst().types())
+      .extracting(TypeDescription::name)
+      .containsExactly("ДвоичныеДанные", "Строка");
+  }
+
+  @Test
+  void parseStructureReturnFieldWithMultilineTypeAndSubfields() {
+    // given: у поля continuation-тип (второй тип на новой строке) несёт собственные подполя (**).
+    var methodDescription = parseMethodDescriptionString("""
+      // Возвращаемое значение:
+      //  Структура:
+      //   * Данные - Строка - произвольные данные.
+      //            - Структура - поля формы:
+      //       ** Ключ - Строка - имя поля.
+      //       ** Значение - Строка - значение поля.
+      //   * Прочее - Булево - признак.
+      """);
+
+    // then: один тип возврата со всеми полями верхнего уровня.
+    assertThat(methodDescription.getReturnedValue()).hasSize(1);
+    var structure = methodDescription.getReturnedValue().getFirst();
+    assertThat(structure.fields())
+      .extracting(ParameterDescription::name)
+      .containsExactly("Данные", "Прочее");
+
+    // оба типа поля Данные на месте, подполя висят на continuation-типе Структура.
+    var dataField = structure.fields().getFirst();
+    assertThat(dataField.types())
+      .extracting(TypeDescription::name)
+      .containsExactly("Строка", "Структура");
+    assertThat(dataField.types().get(1).fields())
+      .extracting(ParameterDescription::name)
+      .containsExactly("Ключ", "Значение");
+  }
+
   private List<Token> getTokensFromString(String exampleString) {
     var tokenizer = new BSLTokenizer(exampleString);
     return tokenizer.getTokens().stream()


### PR DESCRIPTION
## Проблема

Поле возвращаемого значения (или параметра) с **составным типом, записанным на нескольких строках**, парсилось неверно. Формат каноничен по [std453](https://v8std.ru/std/453/) п.5.2.5 и 5.3 («Если возвращаемое значение составного типа, каждый тип пишется с новой строки и с дефиса»):

```bsl
// Возвращаемое значение:
//  Структура:
//   * Подпись - ДвоичныеДанные - результат подписания.
//             - Строка - подписанный КонвертXML.
//   * Комментарий - Строка - комментарий.
```

Continuation-строка `- Строка` воспринималась как **новый тип возвращаемого значения верхнего уровня**: структура «разрезалась» (`returnedValue` = `[Структура, Строка]`), у `Структура` оставалось только поле `Подпись`, а все последующие поля (`Комментарий`, …) навешивались на фантомный `Строка`.

Это видно и на существующем ресурсе `example9.bsl` (поле `Данные`), но там reader-поведение тестами зафиксировано не было — только дерево грамматики.

## Причина

Грамматика матчит continuation-строки с дефисом как `typesBlock`, а `MethodDescriptionReader.visitTypesBlock` безусловно добавлял тип в `lastReadParam` (верхний уровень), игнорируя вложенность в поле — в отличие от `visitReturnsValue`, где уровень учитывается.

## Решение

`visitTypesBlock` теперь маршрутизирует continuation-тип через `addContinuationType`: если у текущего верхнего типа уже есть поля (мы внутри списка свойств структуры), тип уходит в самое глубокое активное поле — по образцу уже существующего `addTypeDescription`. Иначе — добавляется как доп. тип верхнего уровня (прежнее поведение для составных типов без полей). Подполя (`**`) корректно остаются на continuation-типе.

## Тесты

- `parseStructureReturnFieldWithMultilineType` — структура не разрезается, все поля и оба типа поля на месте.
- `parseStructureReturnFieldWithMultilineTypeAndSubfields` — подполя `**` остаются на continuation-типе.
- Полный набор (521 тест) зелёный, регрессий нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)