### PR TITLE
Extract variable type from description start

### DIFF
--- a/src/main/antlr/BSLDescriptionParser.g4
+++ b/src/main/antlr/BSLDescriptionParser.g4
@@ -39,6 +39,18 @@ methodDescription:
     skipBlock?
     EOF;
 
+// структура описания переменной
+// тип переменной указывается в начале первой значимой строки до разделителя " - "
+// (например: "// Строка - описание" или "// СправочникСсылка.Контрагенты - описание").
+// Используется отдельным разбором для извлечения элемента типа, не затрагивая разбор methodDescription.
+variableDescription:
+    deprecateBlock?
+    variableType?
+    .*?
+    EOF;
+
+variableType: startPart returnsValue;
+
 // deprecate
 deprecateBlock: startPart DEPRECATE_KEYWORD (deprecateDescription | EOL);
 deprecateDescription: (hyperlink | ~(EOL | EOF))+ EOL;

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
 import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -100,7 +101,66 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
       .range(range)
       .trailingDescription(trailingDescription);
     reader.visitMethodDescription(ast);
+
+    // Отдельный разбор первой значимой строки описания для извлечения типа переменной
+    // (нотация «тип в начале»). Координаты элементов абсолютные, как и у DEPRECATE_KEYWORD.
+    var typeTokenizer = new VariableDescriptionTokenizer(descriptionText);
+    var variableType = requireNonNull(typeTokenizer.getAst()).variableType();
+    if (variableType != null) {
+      reader.readType(variableType);
+    }
+
     return reader.builder.build();
+  }
+
+  /**
+   * Извлекает элементы типа переменной из разобранной первой строки описания и добавляет их
+   * в строящееся описание как элементы типа {@link DescriptionElement.Type#TYPE_NAME}.
+   */
+  private void readType(BSLDescriptionParser.VariableTypeContext ctx) {
+    var returnsValue = ctx.returnsValue();
+    if (returnsValue != null) {
+      addTypeElements(returnsValue.type());
+    }
+  }
+
+  private void addTypeElements(BSLDescriptionParser.@Nullable TypeContext type) {
+    if (type == null) {
+      return;
+    }
+    var listTypes = type.listTypes();
+    var collectionType = type.collectionType();
+    var simpleType = type.simpleType();
+    if (listTypes != null) {
+      listTypes.listType().forEach(this::addListTypeElement);
+    } else if (collectionType != null) {
+      addCollectionTypeElement(collectionType);
+    } else if (simpleType != null) {
+      addTypeElement(simpleType.typeName);
+    }
+    // hyperlinkType намеренно пропускается — это ссылка, она уже учтена в links,
+    // а не объявление типа переменной.
+  }
+
+  private void addListTypeElement(BSLDescriptionParser.ListTypeContext ctx) {
+    if (ctx.collectionType() != null) {
+      addCollectionTypeElement(ctx.collectionType());
+    } else if (ctx.simpleType() != null) {
+      addTypeElement(ctx.simpleType().typeName);
+    }
+  }
+
+  private void addCollectionTypeElement(BSLDescriptionParser.CollectionTypeContext ctx) {
+    addTypeElement(ctx.collection);
+    addTypeElements(ctx.type());
+  }
+
+  private void addTypeElement(@Nullable Token token) {
+    if (token != null) {
+      builder.element(new DescriptionElement(
+        SimpleRange.create(token, lineShift, firstLineCharShift),
+        DescriptionElement.Type.TYPE_NAME));
+    }
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionTokenizer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionTokenizer.java
@@ -1,0 +1,44 @@
+/*
+ * This file is a part of BSL Parser.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>, Sergey Batanov <sergey.batanov@dmpas.ru>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Parser is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Parser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Parser.
+ */
+package com.github._1c_syntax.bsl.parser.description.reader;
+
+import com.github._1c_syntax.bsl.parser.BSLDescriptionLexer;
+import com.github._1c_syntax.bsl.parser.BSLDescriptionParser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.Tokenizer;
+
+/**
+ * Токенизатор описания переменной, использующий правило разбора с выделением типа в начале описания.
+ */
+class VariableDescriptionTokenizer
+  extends Tokenizer<BSLDescriptionParser.VariableDescriptionContext, BSLDescriptionParser> {
+  public VariableDescriptionTokenizer(String content) {
+    super(content + "\n",
+      new BSLDescriptionLexer(CharStreams.fromString("")),
+      BSLDescriptionParser.class);
+  }
+
+  @Override
+  protected BSLDescriptionParser.VariableDescriptionContext rootAST() {
+    return parser.variableDescription();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
@@ -613,6 +613,58 @@ class BSLDescriptionReaderTest {
   }
 
   @Test
+  void parseVariableDescriptionWithCollectionType() {
+    var exampleString = "// Массив из Строка - описание";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    // тип-коллекция: элементы и для имени коллекции, и для типа значения
+    assertThat(variableDescription.getElements())
+      .hasSize(2)
+      .allMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
+
+    var collectionElement = variableDescription.getElements().getFirst();
+    assertThat(collectionElement.range())
+      .isEqualTo(SimpleRange.create(0, 3, 3 + "Массив".length()));
+
+    var valueElement = variableDescription.getElements().get(1);
+    var valueStart = exampleString.indexOf("Строка");
+    assertThat(valueElement.range())
+      .isEqualTo(SimpleRange.create(0, valueStart, valueStart + "Строка".length()));
+  }
+
+  @Test
+  void parseVariableDescriptionWithTypeList() {
+    var exampleString = "// Строка, Число - описание";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    // перечисление типов через запятую — элемент на каждый тип
+    assertThat(variableDescription.getElements())
+      .hasSize(2)
+      .allMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
+
+    assertThat(variableDescription.getElements().getFirst().range())
+      .isEqualTo(SimpleRange.create(0, 3, 3 + "Строка".length()));
+
+    var secondStart = exampleString.indexOf("Число");
+    assertThat(variableDescription.getElements().get(1).range())
+      .isEqualTo(SimpleRange.create(0, secondStart, secondStart + "Число".length()));
+  }
+
+  @Test
+  void parseVariableDescriptionWithLinkType() {
+    // тип-гиперссылка (См.) не должен порождать TYPE_NAME — это ссылка, она учтена в links
+    var exampleString = "// См. МойМодуль.МойТип - описание";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    assertThat(variableDescription.getLinks()).hasSize(1);
+    assertThat(variableDescription.getElements())
+      .noneMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
+  }
+
+  @Test
   void parseVariableDescriptionWithTypeWithoutSeparator() {
     var exampleString = "// Строка";
     var tokens = getTokensFromString(exampleString);

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
@@ -578,6 +578,92 @@ class BSLDescriptionReaderTest {
   }
 
   @Test
+  void parseVariableDescriptionWithType() {
+    var exampleString = "// Строка - описание переменной";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    assertThat(variableDescription).isNotNull();
+    assertThat(variableDescription.getDescription()).isEqualTo(exampleString);
+    assertThat(variableDescription.getDeprecationInfo()).isEmpty();
+    assertThat(variableDescription.isDeprecated()).isFalse();
+    assertThat(variableDescription.getLinks()).isEmpty();
+
+    assertThat(variableDescription.getElements()).hasSize(1);
+    var typeElement = variableDescription.getElements().getFirst();
+    assertThat(typeElement.type()).isEqualTo(DescriptionElement.Type.TYPE_NAME);
+    // "// " занимает 3 символа, тип "Строка" длиной 6 символов
+    assertThat(typeElement.range()).isEqualTo(SimpleRange.create(0, 3, 9));
+    assertThat(typeElement.range().length()).isEqualTo("Строка".length());
+  }
+
+  @Test
+  void parseVariableDescriptionWithQualifiedType() {
+    var exampleString = "// СправочникСсылка.Контрагенты - описание";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    assertThat(variableDescription.getElements()).hasSize(1);
+    var typeElement = variableDescription.getElements().getFirst();
+    assertThat(typeElement.type()).isEqualTo(DescriptionElement.Type.TYPE_NAME);
+    // составной (квалифицированный) тип разбирается целиком
+    assertThat(typeElement.range().length()).isEqualTo("СправочникСсылка.Контрагенты".length());
+    assertThat(typeElement.range()).isEqualTo(
+      SimpleRange.create(0, 3, 3 + "СправочникСсылка.Контрагенты".length()));
+  }
+
+  @Test
+  void parseVariableDescriptionWithTypeWithoutSeparator() {
+    var exampleString = "// Строка";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    assertThat(variableDescription.getElements()).hasSize(1);
+    var typeElement = variableDescription.getElements().getFirst();
+    assertThat(typeElement.type()).isEqualTo(DescriptionElement.Type.TYPE_NAME);
+    assertThat(typeElement.range()).isEqualTo(SimpleRange.create(0, 3, 9));
+  }
+
+  @Test
+  void parseVariableDescriptionFreeTextWithoutType() {
+    // регресс: свободный текст без типа не должен порождать ложный TYPE_NAME
+    var exampleString = "// Описание переменной";
+    var tokens = getTokensFromString(exampleString);
+    var variableDescription = VariableDescription.create(tokens);
+
+    assertThat(variableDescription.getPurposeDescription()).contains("Описание переменной");
+    assertThat(variableDescription.getElements())
+      .noneMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
+    assertThat(variableDescription.getElements()).isEmpty();
+  }
+
+  @Test
+  void parseTrailingVariableDescriptionWithType() {
+    // Перем Стр; // Строка - описание
+    // Висячий комментарий начинается не со столбца 0, range типа должен быть абсолютным.
+    var leadingComment = "// Ведущее описание";
+    var trailingSource = "Перем Стр; // Строка - описание";
+    var tokens = getTokensFromString(leadingComment);
+    var trailingToken = getTokensFromString(trailingSource).getFirst();
+
+    var variableDescription = VariableDescription.create(tokens, Optional.of(trailingToken));
+
+    assertThat(variableDescription.getTrailingDescription()).isPresent();
+    var trailing = variableDescription.getTrailingDescription().get();
+
+    assertThat(trailing.getElements()).hasSize(1);
+    var typeElement = trailing.getElements().getFirst();
+    assertThat(typeElement.type()).isEqualTo(DescriptionElement.Type.TYPE_NAME);
+    assertThat(typeElement.range().length()).isEqualTo("Строка".length());
+
+    // startCharacter должен быть абсолютным: "Перем Стр; " (11) + "// " (3) = 14
+    var typeStart = trailingSource.indexOf("Строка");
+    assertThat(typeElement.range().startCharacter()).isEqualTo(typeStart);
+    assertThat(typeElement.range())
+      .isEqualTo(SimpleRange.create(0, typeStart, typeStart + "Строка".length()));
+  }
+
+  @Test
   void parseVariableDescription3() {
     var exampleString = "// Устарела. см. НоваяПеременная\n// Описание переменной";
     var tokens = getTokensFromString(exampleString);


### PR DESCRIPTION
## Summary
Add support for extracting variable type information from the beginning of variable descriptions using the "type - description" notation (e.g., "// Строка - описание"). This allows the parser to identify and track type declarations in variable documentation comments.

## Key Changes
- **New grammar rule** (`variableDescription` and `variableType`) in `BSLDescriptionParser.g4` to parse variable descriptions with optional type information at the start
- **New tokenizer class** `VariableDescriptionTokenizer` to parse descriptions using the variable-specific grammar rule
- **Type extraction logic** in `VariableDescriptionReader` to:
  - Parse the first significant line of variable descriptions for type information
  - Extract type elements (simple types, qualified types, collection types, and list types)
  - Add extracted types as `DescriptionElement.Type.TYPE_NAME` elements with absolute coordinates
- **Comprehensive test coverage** with 5 new test cases covering:
  - Simple type extraction ("Строка")
  - Qualified type extraction ("СправочникСсылка.Контрагенты")
  - Type without separator
  - Regression test for free text without type
  - Trailing comment type extraction with proper absolute positioning

## Implementation Details
- Type extraction uses a separate tokenizer to avoid interfering with the existing `methodDescription` parsing
- Coordinates for extracted type elements are absolute (matching `DEPRECATE_KEYWORD` behavior), accounting for line and character shifts
- Supports complex type structures: simple types, qualified types (with dots), collection types, and list types
- Hyperlink types are intentionally skipped as they are already tracked in the links collection

https://claude.ai/code/session_01TX5hqgS58htjayb4thDxXA