### PR TITLE
feat(description): добавить VariableDescription.getTypes() с List&lt;TypeDescription&gt;

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/VariableDescription.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/VariableDescription.java
@@ -74,6 +74,16 @@ public class VariableDescription implements SourceDefinedSymbolDescription {
   SimpleRange range;
 
   /**
+   * Список типов переменной, извлечённых из описания (нотация «тип в начале»).
+   * <p>
+   * Аналогичен {@link MethodDescription#getReturnedValue()}: каждый элемент несёт имя типа
+   * ({@link TypeDescription#name()}) и его область в исходном тексте ({@link TypeDescription#element()}).
+   * Если тип в описании не указан (свободный текст), список пуст.
+   */
+  @Singular
+  List<TypeDescription> types;
+
+  /**
    * Описание "висячего" комментария
    */
   Optional<VariableDescription> trailingDescription;

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
@@ -23,6 +23,9 @@ package com.github._1c_syntax.bsl.parser.description.reader;
 
 import com.github._1c_syntax.bsl.parser.BSLDescriptionParser;
 import com.github._1c_syntax.bsl.parser.BSLDescriptionParserBaseVisitor;
+import com.github._1c_syntax.bsl.parser.description.CollectionTypeDescription;
+import com.github._1c_syntax.bsl.parser.description.SimpleTypeDescription;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.parser.description.VariableDescription;
 import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
 import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
@@ -31,6 +34,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -114,53 +118,99 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
   }
 
   /**
-   * Извлекает элементы типа переменной из разобранной первой строки описания и добавляет их
-   * в строящееся описание как элементы типа {@link DescriptionElement.Type#TYPE_NAME}.
+   * Извлекает типы переменной из разобранной первой строки описания (нотация «тип в начале»),
+   * регистрирует их как {@link TypeDescription} (для {@link VariableDescription#getTypes()}) и
+   * добавляет соответствующие элементы типа {@link DescriptionElement.Type#TYPE_NAME}
+   * (для {@link VariableDescription#getElements()}).
    */
   private void readType(BSLDescriptionParser.VariableTypeContext ctx) {
     var returnsValue = ctx.returnsValue();
-    if (returnsValue != null) {
-      addTypeElements(returnsValue.type());
+    if (returnsValue == null) {
+      return;
+    }
+    for (var type : buildTypes(returnsValue.type())) {
+      builder.type(type);
+      addTypeElements(type);
     }
   }
 
-  private void addTypeElements(BSLDescriptionParser.@Nullable TypeContext type) {
+  private List<TypeDescription> buildTypes(BSLDescriptionParser.@Nullable TypeContext type) {
     if (type == null) {
-      return;
+      return List.of();
     }
     var listTypes = type.listTypes();
     var collectionType = type.collectionType();
     var simpleType = type.simpleType();
     if (listTypes != null) {
-      listTypes.listType().forEach(this::addListTypeElement);
-    } else if (collectionType != null) {
-      addCollectionTypeElement(collectionType);
-    } else if (simpleType != null) {
-      addTypeElement(simpleType.typeName);
+      return listTypes.listType().stream()
+        .map(this::buildListType)
+        .filter(Objects::nonNull)
+        .toList();
+    }
+    if (collectionType != null) {
+      return toList(buildCollectionType(collectionType));
+    }
+    if (simpleType != null) {
+      return toList(buildSimpleType(simpleType));
     }
     // hyperlinkType намеренно пропускается — это ссылка, она уже учтена в links,
     // а не объявление типа переменной.
+    return List.of();
   }
 
-  private void addListTypeElement(BSLDescriptionParser.ListTypeContext ctx) {
+  private @Nullable TypeDescription buildListType(BSLDescriptionParser.ListTypeContext ctx) {
     if (ctx.collectionType() != null) {
-      addCollectionTypeElement(ctx.collectionType());
-    } else if (ctx.simpleType() != null) {
-      addTypeElement(ctx.simpleType().typeName);
+      return buildCollectionType(ctx.collectionType());
+    }
+    if (ctx.simpleType() != null) {
+      return buildSimpleType(ctx.simpleType());
+    }
+    return null;
+  }
+
+  private @Nullable TypeDescription buildCollectionType(BSLDescriptionParser.CollectionTypeContext ctx) {
+    if (ctx.collection == null) {
+      return null;
+    }
+    return CollectionTypeDescription.create(
+      ctx.collection.getText(),
+      newTypeElement(ctx.collection),
+      "",
+      buildTypes(ctx.type()),
+      List.of());
+  }
+
+  private @Nullable TypeDescription buildSimpleType(BSLDescriptionParser.SimpleTypeContext ctx) {
+    if (ctx.typeName == null) {
+      return null;
+    }
+    return SimpleTypeDescription.create(
+      ctx.typeName.getText(),
+      newTypeElement(ctx.typeName),
+      "",
+      List.of());
+  }
+
+  private DescriptionElement newTypeElement(Token token) {
+    return new DescriptionElement(
+      SimpleRange.create(token, lineShift, firstLineCharShift),
+      DescriptionElement.Type.TYPE_NAME);
+  }
+
+  /**
+   * Добавляет в общий список элементов имя самого типа и имена типов значений коллекции,
+   * чтобы {@link VariableDescription#getElements()} покрывал все имена типов в описании
+   * (в том числе вложенные в {@code Массив из ...}).
+   */
+  private void addTypeElements(TypeDescription type) {
+    builder.element(type.element());
+    if (type instanceof CollectionTypeDescription collection) {
+      collection.valueTypes().forEach(this::addTypeElements);
     }
   }
 
-  private void addCollectionTypeElement(BSLDescriptionParser.CollectionTypeContext ctx) {
-    addTypeElement(ctx.collection);
-    addTypeElements(ctx.type());
-  }
-
-  private void addTypeElement(@Nullable Token token) {
-    if (token != null) {
-      builder.element(new DescriptionElement(
-        SimpleRange.create(token, lineShift, firstLineCharShift),
-        DescriptionElement.Type.TYPE_NAME));
-    }
+  private static List<TypeDescription> toList(@Nullable TypeDescription type) {
+    return type == null ? List.of() : List.of(type);
   }
 
   @Override

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/BSLDescriptionReaderTest.java
@@ -595,6 +595,13 @@ class BSLDescriptionReaderTest {
     // "// " занимает 3 символа, тип "Строка" длиной 6 символов
     assertThat(typeElement.range()).isEqualTo(SimpleRange.create(0, 3, 9));
     assertThat(typeElement.range().length()).isEqualTo("Строка".length());
+
+    // удобный аксессор: тип доступен напрямую, без вырезания имени из текста по диапазону
+    assertThat(variableDescription.getTypes()).hasSize(1);
+    var type = variableDescription.getTypes().getFirst();
+    assertThat(type.name()).isEqualTo("Строка");
+    assertThat(type.variant()).isEqualTo(TypeDescription.Variant.SIMPLE);
+    assertThat(type.element()).isEqualTo(typeElement);
   }
 
   @Test
@@ -610,6 +617,9 @@ class BSLDescriptionReaderTest {
     assertThat(typeElement.range().length()).isEqualTo("СправочникСсылка.Контрагенты".length());
     assertThat(typeElement.range()).isEqualTo(
       SimpleRange.create(0, 3, 3 + "СправочникСсылка.Контрагенты".length()));
+
+    assertThat(variableDescription.getTypes()).hasSize(1);
+    assertThat(variableDescription.getTypes().getFirst().name()).isEqualTo("СправочникСсылка.Контрагенты");
   }
 
   @Test
@@ -631,6 +641,17 @@ class BSLDescriptionReaderTest {
     var valueStart = exampleString.indexOf("Строка");
     assertThat(valueElement.range())
       .isEqualTo(SimpleRange.create(0, valueStart, valueStart + "Строка".length()));
+
+    // getTypes(): один тип-коллекция с именем, включающим тип значения, и областью имени коллекции
+    assertThat(variableDescription.getTypes()).hasSize(1);
+    var collectionType = variableDescription.getTypes().getFirst();
+    assertThat(collectionType.variant()).isEqualTo(TypeDescription.Variant.COLLECTION);
+    assertThat(collectionType.name()).isEqualTo("Массив<Строка>");
+    assertThat(collectionType.element()).isEqualTo(collectionElement);
+    assertThat(collectionType).isInstanceOfSatisfying(CollectionTypeDescription.class, ct -> {
+      assertThat(ct.collectionName()).isEqualTo("Массив");
+      assertThat(ct.valueTypes()).extracting(TypeDescription::name).containsExactly("Строка");
+    });
   }
 
   @Test
@@ -650,6 +671,10 @@ class BSLDescriptionReaderTest {
     var secondStart = exampleString.indexOf("Число");
     assertThat(variableDescription.getElements().get(1).range())
       .isEqualTo(SimpleRange.create(0, secondStart, secondStart + "Число".length()));
+
+    assertThat(variableDescription.getTypes())
+      .extracting(TypeDescription::name)
+      .containsExactly("Строка", "Число");
   }
 
   @Test
@@ -662,6 +687,7 @@ class BSLDescriptionReaderTest {
     assertThat(variableDescription.getLinks()).hasSize(1);
     assertThat(variableDescription.getElements())
       .noneMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
+    assertThat(variableDescription.getTypes()).isEmpty();
   }
 
   @Test
@@ -687,6 +713,7 @@ class BSLDescriptionReaderTest {
     assertThat(variableDescription.getElements())
       .noneMatch(element -> element.type() == DescriptionElement.Type.TYPE_NAME);
     assertThat(variableDescription.getElements()).isEmpty();
+    assertThat(variableDescription.getTypes()).isEmpty();
   }
 
   @Test
@@ -713,6 +740,12 @@ class BSLDescriptionReaderTest {
     assertThat(typeElement.range().startCharacter()).isEqualTo(typeStart);
     assertThat(typeElement.range())
       .isEqualTo(SimpleRange.create(0, typeStart, typeStart + "Строка".length()));
+
+    // getTypes() висячего описания тоже доступен, с абсолютной областью имени типа
+    assertThat(trailing.getTypes()).hasSize(1);
+    var type = trailing.getTypes().getFirst();
+    assertThat(type.name()).isEqualTo("Строка");
+    assertThat(type.element().range()).isEqualTo(typeElement.range());
   }
 
   @Test


### PR DESCRIPTION
## Зачем

Follow-up к #391. После #391 тип переменной отдавался только «сырыми» элементами `getElements()` (range + `TYPE_NAME`), и потребителю (например, bsl-language-server) приходилось вырезать имя типа из текста комментария по абсолютному диапазону — неудобно и хрупко, в отличие от `MethodDescription.getReturnedValue() : List<TypeDescription>`.

## Что сделано

- **`VariableDescription`**: добавлен аксессор `getTypes() : List<TypeDescription>` — полный паритет с `MethodDescription.getReturnedValue()`. Каждый элемент несёт `name()`, `variant()`, `fields()` и `element()` с абсолютной областью. Если тип в описании не указан (свободный текст) — список пуст.
- **`VariableDescriptionReader`**: типы строятся из тех же грамматических правил (`type`/`returnsValue`) через существующие фабрики `SimpleTypeDescription` / `CollectionTypeDescription` (гиперссылки `См.` по-прежнему пропускаются — это ссылка, она в `links`).
- **Совместимость**: `getElements()` сохраняет прежнее поведение и продолжает включать имена вложенных типов значений коллекции (`// Массив из Строка` → два `TYPE_NAME`-элемента: `Массив` и `Строка`). Для этого добавлен явный рекурсивный сбор элементов, т.к. `CollectionTypeDescription.allElements()` сам value-типы не отдаёт.

Пример: для `// Массив из Строка - описание` теперь `getTypes()` = один тип `Массив<Строка>` (`collectionName()="Массив"`, `valueTypes()=[Строка]`), а `getElements()` = два TYPE_NAME-элемента (как раньше).

## Тесты

Добавлены проверки `getTypes()` во все типизированные кейсы (простой, квалифицированный, коллекция, список, ссылка, свободный текст, висячее описание). `getDescription()`/`purposeDescription`/`links`/`deprecated` не изменены. Полный прогон `./gradlew test` зелёный.

## Follow-up

После релиза этой версии — поднять зависимость bsl-parser в bsl-language-server (`build.gradle.kts`), тогда подсветка и обработка типа переменной (в т.ч. в висячих комментариях, #4165) сможет читать тип напрямую через `getTypes()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TX5hqgS58htjayb4thDxXA)_