### PR TITLE
fix(description): координаты элементов учитывают отступ каждой строки

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/MethodDescriptionReader.java
@@ -61,17 +61,18 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
   private final int lineShift;
 
   /**
-   * Сдвиг номера символа относительно исходного текста (только для первой строки)
+   * Сдвиг номера символа на каждой строке исходного текста: строки описания могут
+   * иметь отступ, и у каждой он свой
    */
-  private final int firstLineCharShift;
+  private final int[] charShifts;
 
   private TempParameterData lastReadParam;
   private int typeLevel = -1;
 
-  private MethodDescriptionReader(SimpleRange range) {
+  private MethodDescriptionReader(SimpleRange range, int[] charShifts) {
     builder = MethodDescription.builder();
     lineShift = Math.max(0, range.startLine());
-    firstLineCharShift = Math.max(0, range.startCharacter());
+    this.charShifts = charShifts;
     lastReadParam = TempParameterData.empty();
   }
 
@@ -87,7 +88,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
       .map(Token::getText)
       .collect(Collectors.joining("\n"));
 
-    return read(description, SimpleRange.create(comments));
+    return read(description, SimpleRange.create(comments), ReaderUtils.charShifts(comments));
   }
 
   /**
@@ -99,13 +100,17 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
    * @return Описание метода.
    */
   private static MethodDescription read(String descriptionText, SimpleRange range) {
+    return read(descriptionText, range, new int[]{Math.max(0, range.startCharacter())});
+  }
+
+  private static MethodDescription read(String descriptionText, SimpleRange range, int[] charShifts) {
     var tokenizer = new MethodDescriptionTokenizer(descriptionText);
     var ast = requireNonNull(tokenizer.getAst());
 
-    var reader = new MethodDescriptionReader(range);
+    var reader = new MethodDescriptionReader(range, charShifts);
     reader.builder
       .description(descriptionText.strip())
-      .links(ReaderUtils.readLinks(ast, reader.lineShift, reader.firstLineCharShift))
+      .links(ReaderUtils.readLinks(ast, reader.lineShift, reader.charShifts))
       .range(range);
     reader.visitMethodDescription(ast);
     return reader.builder.build();
@@ -195,7 +200,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
             lastReadParam = TempParameterData.empty();
             super.visitParametersBlock(ctx);
             if (!lastReadParam.isEmpty()) {
-              builder.parameter(lastReadParam.build(lineShift, firstLineCharShift));
+              builder.parameter(lastReadParam.build(lineShift, charShifts));
             }
           }
         }
@@ -206,7 +211,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
   @Override
   public @Nullable ParseTree visitParameter(BSLDescriptionParser.ParameterContext ctx) {
     if (!lastReadParam.isEmpty()) {
-      builder.parameter(lastReadParam.build(lineShift, firstLineCharShift));
+      builder.parameter(lastReadParam.build(lineShift, charShifts));
     }
     lastReadParam = TempParameterData.create(ctx);
     return super.visitParameter(ctx);
@@ -261,7 +266,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
             lastReadParam = TempParameterData.fake();
             typeLevel = -1;
             super.visitReturnsValuesBlock(ctx);
-            builder.returnedValue(lastReadParam.build(lineShift, firstLineCharShift).types());
+            builder.returnedValue(lastReadParam.build(lineShift, charShifts).types());
           }
         }
       );
@@ -301,7 +306,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
 
   private DescriptionElement newElement(Token token, DescriptionElement.Type type) {
     return new DescriptionElement(
-      SimpleRange.create(token, lineShift, firstLineCharShift),
+      SimpleRange.create(token, lineShift, charShifts),
       type);
   }
 
@@ -374,13 +379,13 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
       return Optional.empty();
     }
 
-    private ParameterDescription build(int lineShift, int firstLineCharShift) {
-      var newRange = SimpleRange.shift(range, lineShift, firstLineCharShift);
+    private ParameterDescription build(int lineShift, int[] charShifts) {
+      var newRange = SimpleRange.shift(range, lineShift, charShifts);
       return new ParameterDescription(
         name,
         new DescriptionElement(newRange, DescriptionElement.Type.PARAMETER_NAME),
         types.stream()
-          .map(type -> type.build(lineShift, firstLineCharShift))
+          .map(type -> type.build(lineShift, charShifts))
           .toList()
       );
     }
@@ -606,12 +611,12 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
       valueTypes.addAll(fakeParam.types);
     }
 
-    private TypeDescription build(int lineShift, int firstLineCharShift) {
+    private TypeDescription build(int lineShift, int[] charShifts) {
       var fieldList = fields.stream()
-        .map(fld -> fld.build(lineShift, firstLineCharShift))
+        .map(fld -> fld.build(lineShift, charShifts))
         .toList();
 
-      var newRange = SimpleRange.shift(range, lineShift, firstLineCharShift);
+      var newRange = SimpleRange.shift(range, lineShift, charShifts);
       var element = new DescriptionElement(newRange, DescriptionElement.Type.TYPE_NAME);
 
       return switch (variant) {
@@ -619,7 +624,7 @@ public final class MethodDescriptionReader extends BSLDescriptionParserBaseVisit
         case COLLECTION -> CollectionTypeDescription.create(
           name, element, description.toString(),
           valueTypes.stream()
-            .map(vt -> vt.build(lineShift, firstLineCharShift))
+            .map(vt -> vt.build(lineShift, charShifts))
             .toList(),
           fieldList
         );

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/ReaderUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/ReaderUtils.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import lombok.experimental.UtilityClass;
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.Trees;
 
 import java.util.Collection;
@@ -73,7 +74,20 @@ public class ReaderUtils {
    *
    * @return Список ссылок
    */
-  public List<Hyperlink> readLinks(ParserRuleContext ast, int lineShift, int firstLineCharShift) {
+  /**
+   * Сдвиг символов на каждой строке описания: строка описания начинается там, где стоит
+   * её комментарий, и отступ у каждой свой.
+   *
+   * @param comments Токены комментариев описания
+   * @return Сдвиг на каждую строку описания
+   */
+  public int[] charShifts(List<Token> comments) {
+    return comments.stream()
+      .mapToInt(Token::getCharPositionInLine)
+      .toArray();
+  }
+
+  public List<Hyperlink> readLinks(ParserRuleContext ast, int lineShift, int[] charShifts) {
     Collection<BSLDescriptionParser.HyperlinkContext> links =
       Trees.findAllRuleNodes(ast, BSLDescriptionParser.RULE_hyperlink);
     if (!links.isEmpty()) {
@@ -83,7 +97,7 @@ public class ReaderUtils {
             var link = hyperlinkContext.link == null ? "" : hyperlinkContext.link.getText();
             var params = hyperlinkContext.linkParams == null ? "" : hyperlinkContext.linkParams.getText();
             var range = SimpleRange.create(hyperlinkContext.getStart(), hyperlinkContext.getStop());
-            var shiftedRange = SimpleRange.shift(range, lineShift, firstLineCharShift);
+            var shiftedRange = SimpleRange.shift(range, lineShift, charShifts);
             return Hyperlink.create(link, params, shiftedRange);
           })
         .toList();

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/ReaderUtils.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/ReaderUtils.java
@@ -66,19 +66,11 @@ public class ReaderUtils {
   }
 
   /**
-   * Извлекает все ссылки из всех подчиненных узлов указанного
-   *
-   * @param ast                Корневой узел дерева для извлечения ссылок
-   * @param lineShift          Сдвиг строк для корректировки позиций
-   * @param firstLineCharShift Сдвиг символов в первой строке для корректировки позиций
-   *
-   * @return Список ссылок
-   */
-  /**
    * Сдвиг символов на каждой строке описания: строка описания начинается там, где стоит
    * её комментарий, и отступ у каждой свой.
    *
    * @param comments Токены комментариев описания
+   *
    * @return Сдвиг на каждую строку описания
    */
   public int[] charShifts(List<Token> comments) {
@@ -87,6 +79,15 @@ public class ReaderUtils {
       .toArray();
   }
 
+  /**
+   * Извлекает все ссылки из всех подчиненных узлов указанного
+   *
+   * @param ast        Корневой узел дерева для извлечения ссылок
+   * @param lineShift  Сдвиг строк для корректировки позиций
+   * @param charShifts Сдвиг символов на каждой строке для корректировки позиций
+   *
+   * @return Список ссылок
+   */
   public List<Hyperlink> readLinks(ParserRuleContext ast, int lineShift, int[] charShifts) {
     Collection<BSLDescriptionParser.HyperlinkContext> links =
       Trees.findAllRuleNodes(ast, BSLDescriptionParser.RULE_hyperlink);

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/reader/VariableDescriptionReader.java
@@ -53,14 +53,15 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
   private final int lineShift;
 
   /**
-   * Сдвиг номера символа относительно исходного текста (только для первой строки)
+   * Сдвиг номера символа на каждой строке исходного текста: строки описания могут
+   * иметь отступ, и у каждой он свой
    */
-  private final int firstLineCharShift;
+  private final int[] charShifts;
 
-  private VariableDescriptionReader(SimpleRange range) {
+  private VariableDescriptionReader(SimpleRange range, int[] charShifts) {
     builder = VariableDescription.builder();
     lineShift = Math.max(0, range.startLine());
-    firstLineCharShift = Math.max(0, range.startCharacter());
+    this.charShifts = charShifts;
   }
 
   /**
@@ -89,19 +90,28 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
 
     return read(description,
       SimpleRange.create(comments),
-      trailingComment.map(List::of).map(VariableDescription::create));
+      trailingComment.map(List::of).map(VariableDescription::create),
+      ReaderUtils.charShifts(comments));
   }
 
   private static VariableDescription read(String descriptionText,
                                           SimpleRange range,
                                           Optional<VariableDescription> trailingDescription) {
+    return read(descriptionText, range, trailingDescription,
+      new int[]{Math.max(0, range.startCharacter())});
+  }
+
+  private static VariableDescription read(String descriptionText,
+                                          SimpleRange range,
+                                          Optional<VariableDescription> trailingDescription,
+                                          int[] charShifts) {
     var tokenizer = new MethodDescriptionTokenizer(descriptionText);
     var ast = requireNonNull(tokenizer.getAst());
 
-    var reader = new VariableDescriptionReader(range);
+    var reader = new VariableDescriptionReader(range, charShifts);
     reader.builder
       .description(descriptionText.strip())
-      .links(ReaderUtils.readLinks(ast, reader.lineShift, reader.firstLineCharShift))
+      .links(ReaderUtils.readLinks(ast, reader.lineShift, reader.charShifts))
       .range(range)
       .trailingDescription(trailingDescription);
     reader.visitMethodDescription(ast);
@@ -193,7 +203,7 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
 
   private DescriptionElement newTypeElement(Token token) {
     return new DescriptionElement(
-      SimpleRange.create(token, lineShift, firstLineCharShift),
+      SimpleRange.create(token, lineShift, charShifts),
       DescriptionElement.Type.TYPE_NAME);
   }
 
@@ -218,7 +228,7 @@ public final class VariableDescriptionReader extends BSLDescriptionParserBaseVis
     builder.deprecated(true);
     Optional.ofNullable(ctx.DEPRECATE_KEYWORD())
       .ifPresent(keyword -> builder.element(new DescriptionElement(
-        SimpleRange.create(keyword.getSymbol(), lineShift, firstLineCharShift),
+        SimpleRange.create(keyword.getSymbol(), lineShift, charShifts),
         DescriptionElement.Type.DEPRECATE_KEYWORD)
       ));
 

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRange.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRange.java
@@ -94,6 +94,19 @@ public record SimpleRange(int startLine, int startCharacter, int endLine, int en
    * @return Область
    */
   public static SimpleRange create(Token token, int lineShift, int firstLineCharShift) {
+    return create(token, lineShift, new int[]{firstLineCharShift});
+  }
+
+  /**
+   * Создает область по токену с учетом сдвигов.
+   *
+   * @param token      Токен
+   * @param lineShift  Сдвиг номера строки. По сути - номер первой строки относительно исходного текста.
+   * @param charShifts Сдвиг первого символа на каждой строке исходного текста: строки описания
+   *                   могут иметь отступ, и у каждой он свой. Строки за пределами массива не сдвигаются.
+   * @return Созданная область
+   */
+  public static SimpleRange create(Token token, int lineShift, int[] charShifts) {
     int startLine = token.getLine() - 1;
     int startChar = token.getCharPositionInLine();
     int endChar;
@@ -102,13 +115,23 @@ public record SimpleRange(int startLine, int startCharacter, int endLine, int en
     } else {
       endChar = token.getCharPositionInLine() + token.getText().length();
     }
-    if (startLine == 0) {
-      startChar += firstLineCharShift;
-      endChar += firstLineCharShift;
-    }
+    var charShift = charShiftOf(charShifts, startLine);
+    startChar += charShift;
+    endChar += charShift;
 
     startLine += lineShift;
     return new SimpleRange(startLine, startChar, startLine, endChar);
+  }
+
+  /**
+   * Сдвиг символов для строки исходного текста.
+   *
+   * @param charShifts Сдвиги по строкам
+   * @param line       Номер строки в исходном тексте
+   * @return Сдвиг; ноль, если для строки он не задан
+   */
+  private static int charShiftOf(int[] charShifts, int line) {
+    return line >= 0 && line < charShifts.length ? charShifts[line] : 0;
   }
 
   /**
@@ -201,15 +224,29 @@ public record SimpleRange(int startLine, int startCharacter, int endLine, int en
    * @return Новый сдвинутый диапазон
    */
   public static SimpleRange shift(SimpleRange range, int lineShift, int firstLineCharShift) {
-    if (lineShift == 0 && firstLineCharShift == 0) {
+    return shift(range, lineShift, new int[]{firstLineCharShift});
+  }
+
+  /**
+   * Создает новый диапазон с учетом сдвига строк и построчных сдвигов символов
+   *
+   * @param range      Диапазон, который нужно сдвинуть
+   * @param lineShift  Сдвиг номера строки
+   * @param charShifts Сдвиг первого символа на каждой строке исходного текста
+   * @return Новый сдвинутый диапазон
+   */
+  public static SimpleRange shift(SimpleRange range, int lineShift, int[] charShifts) {
+    var startShift = charShiftOf(charShifts, range.startLine());
+    var endShift = charShiftOf(charShifts, range.endLine());
+    if (lineShift == 0 && startShift == 0 && endShift == 0) {
       return range;
     }
 
     return SimpleRange.create(
       range.startLine() + lineShift,
-      range.startCharacter() + (range.startLine() == 0 ? firstLineCharShift : 0),
+      range.startCharacter() + startShift,
       range.endLine() + lineShift,
-      range.endCharacter() + (range.endLine() == 0 ? firstLineCharShift : 0)
+      range.endCharacter() + endShift
     );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRange.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRange.java
@@ -83,28 +83,16 @@ public record SimpleRange(int startLine, int startCharacter, int endLine, int en
   }
 
   /**
-   * Создает область по одному токену с учетом заданного сдвига.
+   * Создает область по одному токену с учетом заданных сдвигов.
    * <br/>
    * Используется для создания области, соответствующей положению в исходном тексте на основании токена текста описания.
    *
-   * @param token              Токен, для которого нужно создать область
-   * @param lineShift          Сдвиг номера строки. По сути - номер первой строки относительно исходного текста.
-   * @param firstLineCharShift Сдвиг первого символа. Применяется только для токенов в первой строке,
-   *                           т.к. начальная позиция анализируемого текста могла быть отличной от начала строки
-   * @return Область
-   */
-  public static SimpleRange create(Token token, int lineShift, int firstLineCharShift) {
-    return create(token, lineShift, new int[]{firstLineCharShift});
-  }
-
-  /**
-   * Создает область по токену с учетом сдвигов.
-   *
-   * @param token      Токен
+   * @param token      Токен, для которого нужно создать область
    * @param lineShift  Сдвиг номера строки. По сути - номер первой строки относительно исходного текста.
-   * @param charShifts Сдвиг первого символа на каждой строке исходного текста: строки описания
-   *                   могут иметь отступ, и у каждой он свой. Строки за пределами массива не сдвигаются.
-   * @return Созданная область
+   * @param charShifts Сдвиг первого символа на каждой строке исходного текста: строка описания
+   *                   начинается там, где стоит её комментарий, и отступ у каждой свой.
+   *                   Строки за пределами массива не сдвигаются.
+   * @return Область
    */
   public static SimpleRange create(Token token, int lineShift, int[] charShifts) {
     int startLine = token.getLine() - 1;
@@ -215,17 +203,6 @@ public record SimpleRange(int startLine, int startCharacter, int endLine, int en
     return Math.max(0, endCharacter - startCharacter);
   }
 
-  /**
-   * Создает новый диапазон с учетом сдвигов строк и символов
-   *
-   * @param range            Диапазон, который нужно сдвинуть
-   * @param lineShift        Сдвиг номера строки
-   * @param firstLineCharShift Сдвиг первого символа для токенов в первой строке
-   * @return Новый сдвинутый диапазон
-   */
-  public static SimpleRange shift(SimpleRange range, int lineShift, int firstLineCharShift) {
-    return shift(range, lineShift, new int[]{firstLineCharShift});
-  }
 
   /**
    * Создает новый диапазон с учетом сдвига строк и построчных сдвигов символов

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/DescriptionIndentedRangeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/DescriptionIndentedRangeTest.java
@@ -2,7 +2,7 @@
  * This file is a part of BSL Parser.
  *
  * Copyright (c) 2018-2026
- * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>, Sergey Batanov <sergey.batanov@dmpas.ru>
  *
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/DescriptionIndentedRangeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/reader/DescriptionIndentedRangeTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is a part of BSL Parser.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Parser is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Parser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Parser.
+ */
+package com.github._1c_syntax.bsl.parser.description.reader;
+
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import com.github._1c_syntax.bsl.parser.BSLTokenizer;
+import com.github._1c_syntax.bsl.parser.description.MethodDescription;
+import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Координаты элементов описания отсчитываются от начала файла на каждой строке,
+ * а не только на первой: строки описания могут иметь отступ, и он у каждой свой.
+ */
+class DescriptionIndentedRangeTest {
+
+  private List<Token> getTokens(String example) {
+    var tokenizer = new BSLTokenizer(example);
+    return tokenizer.getTokens().stream()
+      .filter(token -> token.getType() == BSLParser.LINE_COMMENT)
+      .collect(Collectors.toList());
+  }
+
+  @Test
+  void elementRangesAccountForIndentOfEveryLine() {
+    // given: отступ первой строки — 4, второй — 8.
+    var src = "    // Параметры:\n        //  Парам - Строка - описание\n";
+
+    // when
+    var description = MethodDescription.create(getTokens(src));
+
+    // then: ключевое слово «Параметры:» стоит в столбце 7, имя параметра — в 12.
+    assertThat(description.getElements())
+      .filteredOn(element -> element.type() == DescriptionElement.Type.PARAMETERS_KEYWORD)
+      .singleElement()
+      .satisfies(element -> {
+        assertThat(element.range().startLine()).isZero();
+        assertThat(element.range().startCharacter()).isEqualTo(7);
+      });
+    assertThat(description.getElements())
+      .filteredOn(element -> element.type() == DescriptionElement.Type.PARAMETER_NAME)
+      .singleElement()
+      .satisfies(element -> {
+        assertThat(element.range().startLine()).isEqualTo(1);
+        assertThat(element.range().startCharacter()).isEqualTo(12);
+      });
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRangeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/parser/description/support/SimpleRangeTest.java
@@ -199,10 +199,10 @@ class SimpleRangeTest {
     token.setText("test");
 
     int lineShift = 2;
-    int firstLineCharShift = 3;
+    int[] charShifts = {3};
 
     // when
-    var result = SimpleRange.create(token, lineShift, firstLineCharShift);
+    var result = SimpleRange.create(token, lineShift, charShifts);
 
     // then
     assertThat(result.startLine()).isEqualTo(2); // 1 - 1 + 2
@@ -220,14 +220,14 @@ class SimpleRangeTest {
     token.setText("test");
 
     int lineShift = 2;
-    int firstLineCharShift = 3;
+    int[] charShifts = {3};
 
     // when
-    var result = SimpleRange.create(token, lineShift, firstLineCharShift);
+    var result = SimpleRange.create(token, lineShift, charShifts);
 
     // then
     assertThat(result.startLine()).isEqualTo(3); // 2 - 1 + 2
-    assertThat(result.startCharacter()).isEqualTo(5); // no shift for non-first line
+    assertThat(result.startCharacter()).isEqualTo(5); // для строки без своего сдвига он нулевой
     assertThat(result.endLine()).isEqualTo(3); // same as startLine
     assertThat(result.endCharacter()).isEqualTo(9); // 5 + 4 (length of "test")
   }
@@ -240,10 +240,10 @@ class SimpleRangeTest {
     token.setCharPositionInLine(5);
 
     int lineShift = 2;
-    int firstLineCharShift = 3;
+    int[] charShifts = {3};
 
     // when
-    var result = SimpleRange.create(token, lineShift, firstLineCharShift);
+    var result = SimpleRange.create(token, lineShift, charShifts);
 
     // then
     assertThat(result.startLine()).isEqualTo(2); // 1 - 1 + 2


### PR DESCRIPTION
Closes #403

## Что было

Сдвиг символов применялся только к первой строке описания:

```java
if (startLine == 0) {
  startChar += firstLineCharShift;
  endChar += firstLineCharShift;
}
```

а читатель знал ровно один столбец — `range.startCharacter()`. Поэтому на строках после первой координаты элементов оставались отсчитанными от начала комментария:

```bsl
    // Параметры:
        //  Парам - Строка - описание
```

`Парам` стоит в столбце 12, а диапазон отдавался с 4 — и не менялся при изменении отступа строки вовсе.

## Что стало

Отступ известен построчно: у каждого токена комментария свой `getCharPositionInLine()`. Сдвиги собираются массивом (`ReaderUtils.charShifts`) и применяются по номеру строки в `SimpleRange.create`/`shift`.

Перегрузки с одним сдвигом на всё описание удалены: они оставляли прежнее неверное поведение доступным, а вызывающих у них не было — ни в парсере, ни в bsl-language-server (там используются только координатные фабрики `SimpleRange.create(int, int, int[, int])`).

## Проверка

Новый `DescriptionIndentedRangeTest`: описание с разными отступами строк (4 и 8), проверяются координаты ключевого слова на первой строке и имени параметра на второй. До правки тест красный — 4 вместо 12. Полный прогон — 534 теста, падений нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnWpDdNSEFohPZHG6voe6y